### PR TITLE
fix: extract plugin name from versioned cache paths correctly

### DIFF
--- a/packages/han/lib/commands/hook/dispatch.ts
+++ b/packages/han/lib/commands/hook/dispatch.ts
@@ -9,6 +9,7 @@ import {
 	type MarketplaceConfig,
 	readSettingsFile,
 } from "../../claude-settings.ts";
+import { getPluginNameFromRoot } from "../../shared.ts";
 
 /**
  * Read and parse stdin JSON payload from Claude Code hooks
@@ -212,7 +213,7 @@ function executeCommandHook(
 		reportHookExecution({
 			hookType,
 			hookName,
-			hookSource: extractPluginName(pluginRoot),
+			hookSource: getPluginNameFromRoot(pluginRoot),
 			durationMs: duration,
 			exitCode: 0,
 			passed: true,
@@ -230,7 +231,7 @@ function executeCommandHook(
 		reportHookExecution({
 			hookType,
 			hookName,
-			hookSource: extractPluginName(pluginRoot),
+			hookSource: getPluginNameFromRoot(pluginRoot),
 			durationMs: duration,
 			exitCode,
 			passed: false,
@@ -267,17 +268,6 @@ function reportHookExecution(data: {
 	} catch {
 		// Silently fail - don't block hooks on metrics failures
 	}
-}
-
-/**
- * Extract plugin name from plugin root path
- */
-export function extractPluginName(pluginRoot: string): string {
-	// Examples:
-	// /path/to/plugins/marketplaces/han/jutsu/jutsu-typescript -> jutsu-typescript
-	// /path/to/plugins/marketplaces/han/core -> core
-	const parts = pluginRoot.split("/");
-	return parts[parts.length - 1];
 }
 
 /**

--- a/packages/han/lib/commands/metrics/hook-tracking.ts
+++ b/packages/han/lib/commands/metrics/hook-tracking.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { JsonlMetricsStorage } from "../../metrics/jsonl-storage.ts";
+import { getPluginNameFromRoot } from "../../shared.ts";
 
 /**
  * Get storage instance
@@ -61,15 +62,4 @@ export async function recordHookExecution(): Promise<void> {
 		console.error("Failed to record hook execution:", error);
 		process.exit(1);
 	}
-}
-
-/**
- * Extract plugin name from plugin root path
- */
-export function extractPluginName(pluginRoot: string): string {
-	// Examples:
-	// /path/to/plugins/marketplaces/han/jutsu/jutsu-typescript -> jutsu-typescript
-	// /path/to/plugins/marketplaces/han/core -> core
-	const parts = pluginRoot.split("/");
-	return parts[parts.length - 1];
 }

--- a/packages/han/lib/hook-config.ts
+++ b/packages/han/lib/hook-config.ts
@@ -8,6 +8,7 @@ import {
 	validateUserConfig,
 } from "./config-validator.ts";
 import { findDirectoriesWithMarkers } from "./hook-cache.ts";
+import { getPluginNameFromRoot } from "./shared.ts";
 
 /**
  * Plugin hook configuration (from han-config.json)
@@ -149,23 +150,6 @@ export function loadUserConfig(
 		console.error(`Error loading user config from ${configPath}:`, error);
 		return null;
 	}
-}
-
-/**
- * Extract plugin name from CLAUDE_PLUGIN_ROOT path
- * e.g., /path/to/jutsu-elixir -> jutsu-elixir
- * e.g., /path/to/jutsu-elixir/1.1.1 -> jutsu-elixir (versioned cache path)
- */
-export function getPluginNameFromRoot(pluginRoot: string): string {
-	const parts = pluginRoot.split("/").filter(Boolean);
-	const lastPart = parts[parts.length - 1] || "";
-
-	// If last part looks like a version (semver pattern), use parent directory
-	if (/^\d+\.\d+\.\d+/.test(lastPart) && parts.length >= 2) {
-		return parts[parts.length - 2];
-	}
-
-	return lastPart;
 }
 
 /**

--- a/packages/han/lib/shared.ts
+++ b/packages/han/lib/shared.ts
@@ -579,6 +579,27 @@ export async function fetchMarketplace(
 }
 
 /**
+ * Extract plugin name from plugin root path, handling versioned cache paths.
+ *
+ * Examples:
+ * - /path/to/jutsu-elixir -> jutsu-elixir
+ * - /path/to/jutsu-elixir/1.1.1 -> jutsu-elixir (versioned cache path)
+ * - /path/to/plugins/marketplaces/han/jutsu/jutsu-typescript -> jutsu-typescript
+ * - /path/to/plugins/marketplaces/han/core -> core
+ */
+export function getPluginNameFromRoot(pluginRoot: string): string {
+	const parts = pluginRoot.split("/").filter(Boolean);
+	const lastPart = parts[parts.length - 1] || "";
+
+	// If last part looks like a version (semver pattern), use parent directory
+	if (/^\d+\.\d+\.\d+/.test(lastPart) && parts.length >= 2) {
+		return parts[parts.length - 2];
+	}
+
+	return lastPart;
+}
+
+/**
  * Parse plugin recommendations from agent response
  */
 export function parsePluginRecommendations(content: string): string[] {

--- a/packages/han/lib/validate.ts
+++ b/packages/han/lib/validate.ts
@@ -13,9 +13,9 @@ import {
 } from "./hook-cache.ts";
 import {
 	getHookConfigs,
-	getPluginNameFromRoot,
 	type ResolvedHookConfig,
 } from "./hook-config.ts";
+import { getPluginNameFromRoot } from "./shared.ts";
 import {
 	checkFailureSignal,
 	clearFailureSignal,

--- a/packages/han/test/hook-tracking-helpers.test.ts
+++ b/packages/han/test/hook-tracking-helpers.test.ts
@@ -4,68 +4,90 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import { extractPluginName } from "../lib/commands/metrics/hook-tracking.ts";
+import { getPluginNameFromRoot } from "../lib/shared.ts";
 
 describe("hook-tracking.ts helper functions", () => {
-	describe("extractPluginName", () => {
+	describe("getPluginNameFromRoot", () => {
 		test("extracts plugin name from jutsu path", () => {
-			const result = extractPluginName(
+			const result = getPluginNameFromRoot(
 				"/path/to/plugins/marketplaces/han/jutsu/jutsu-typescript",
 			);
 			expect(result).toBe("jutsu-typescript");
 		});
 
 		test("extracts plugin name from core path", () => {
-			const result = extractPluginName(
+			const result = getPluginNameFromRoot(
 				"/path/to/plugins/marketplaces/han/core",
 			);
 			expect(result).toBe("core");
 		});
 
 		test("extracts plugin name from do path", () => {
-			const result = extractPluginName(
+			const result = getPluginNameFromRoot(
 				"/path/to/plugins/marketplaces/han/do/do-accessibility-engineering",
 			);
 			expect(result).toBe("do-accessibility-engineering");
 		});
 
 		test("extracts plugin name from hashi path", () => {
-			const result = extractPluginName(
+			const result = getPluginNameFromRoot(
 				"/path/to/plugins/marketplaces/han/hashi/hashi-github",
 			);
 			expect(result).toBe("hashi-github");
 		});
 
 		test("handles simple path", () => {
-			const result = extractPluginName("/plugins/my-plugin");
+			const result = getPluginNameFromRoot("/plugins/my-plugin");
 			expect(result).toBe("my-plugin");
 		});
 
 		test("handles single segment path", () => {
-			const result = extractPluginName("plugin-name");
+			const result = getPluginNameFromRoot("plugin-name");
 			expect(result).toBe("plugin-name");
 		});
 
 		test("handles path with trailing slash", () => {
-			// Note: trailing slash would result in empty string as last segment
-			const result = extractPluginName("/path/to/plugin/");
-			expect(result).toBe("");
+			// Note: trailing slash is handled by filter(Boolean)
+			const result = getPluginNameFromRoot("/path/to/plugin/");
+			expect(result).toBe("plugin");
 		});
 
 		test("handles root path", () => {
-			const result = extractPluginName("/");
+			const result = getPluginNameFromRoot("/");
 			expect(result).toBe("");
 		});
 
 		test("handles empty string", () => {
-			const result = extractPluginName("");
+			const result = getPluginNameFromRoot("");
 			expect(result).toBe("");
 		});
 
 		test("handles Windows-style path if split on forward slash", () => {
 			// This tests that function uses "/" for splitting
-			const result = extractPluginName("C:/Users/plugins/my-plugin");
+			const result = getPluginNameFromRoot("C:/Users/plugins/my-plugin");
 			expect(result).toBe("my-plugin");
+		});
+
+		// Tests for versioned cache paths
+		test("handles versioned cache path", () => {
+			const result = getPluginNameFromRoot(
+				"/path/to/plugins/cache/han/jutsu-tailwind/1.1.1",
+			);
+			expect(result).toBe("jutsu-tailwind");
+		});
+
+		test("handles versioned cache path with pre-release", () => {
+			const result = getPluginNameFromRoot(
+				"/path/to/plugins/cache/han/jutsu-typescript/1.8.13-beta.1",
+			);
+			expect(result).toBe("jutsu-typescript");
+		});
+
+		test("handles versioned cache path with zero versions", () => {
+			const result = getPluginNameFromRoot(
+				"/path/to/plugins/cache/han/jutsu-react/0.1.0",
+			);
+			expect(result).toBe("jutsu-react");
 		});
 	});
 });

--- a/packages/han/test/validate-unit.test.ts
+++ b/packages/han/test/validate-unit.test.ts
@@ -12,11 +12,11 @@ import { join } from "node:path";
 import {
 	getHookConfigs,
 	getHookDefinition,
-	getPluginNameFromRoot,
 	listAvailableHooks,
 	loadPluginConfig,
 	loadUserConfig,
 } from "../lib/hook-config.ts";
+import { getPluginNameFromRoot } from "../lib/shared.ts";
 
 let testDir: string;
 let pluginDir: string;


### PR DESCRIPTION
Fix getPluginNameFromRoot() to detect and handle versioned cache paths like `~/.claude/plugins/cache/han/jutsu-tailwind/1.1.1` by checking if the last path segment matches a semver pattern. When detected, it returns the parent directory name instead.

This resolves "Plugin name mismatch" errors that occurred when hooks ran from versioned plugin cache directories.

Fixes #12

Generated with [Claude Code](https://claude.ai/code)