### PR TITLE
refactor: remove all prompt hooks

### DIFF
--- a/core/hooks/hooks.json
+++ b/core/hooks/hooks.json
@@ -23,32 +23,6 @@
         ]
       }
     ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "# Review Task Alignment\n\nYou are evaluating whether Claude's work aligns with the user's original request.\n\n## Context\n\n$ARGUMENTS\n\n## Review Checklist\n\n1. **Original Intent**: Does the most recent work align with the user's initial request or the established goal?\n\n2. **Scope Adherence**: Have we stayed within the original scope, or have we drifted into tangential work?\n\n3. **User Expectations**: Does the current state match what the user asked for in their most recent prompt?\n\n4. **Completion Status**: If the original task is incomplete, acknowledge what remains to be done.\n\n## Decision Criteria\n\n**Approve** if work aligns with original request\n**Block** if work has significantly drifted from user's intent\n\nRespond with JSON: {\"decision\": \"approve\" or \"block\", \"reason\": \"your explanation\", \"systemMessage\": \"✓ Task alignment verified\" or \"⚠️ Task drift detected\"}",
-            "timeout": 300
-          },
-          {
-            "type": "prompt",
-            "prompt": "# Professional Honesty Verification\n\nYou are evaluating whether Claude followed professional honesty principles in this conversation.\n\n## Context\n\n$ARGUMENTS\n\n## Step 1: Meta-Check - Did You Read Required Files?\n\n**CRITICAL QUESTION: Were you asked to read files via <must-read-first> tags in system-reminder blocks?**\n\nCheck your context for system-reminder tags containing:\n- `<must-read-first reason=\"epistemic rigor and professional honesty\">...professional-honesty.md</must-read-first>`\n- Any other `<must-read-first>` tags\n\n**If you saw these tags but did NOT actually read the files before responding:**\n- Return `{\"decision\": \"block\", \"reason\": \"Failed to read required files before responding\"}`\n\n**If you saw these tags and DID read them, proceed to Step 2.**\n\n## Step 2: Analyze Your Response\n\nReview your most recent response. Check for violations:\n\n**HIGH CONFIDENCE VIOLATIONS - Auto-block:**\n\n- Used forbidden phrases without verification evidence:\n  - \"You're absolutely right\"\n  - \"That's correct\" \n  - \"Indeed\"\n  - \"Exactly\"\n  - \"That makes sense\"\n- Accepted user claims about code/bugs/performance without verification\n- Started implementation based on unverified user description\n- No tool usage (Read/Grep/Bash) before agreeing with verifiable claims\n\n**ACCEPTABLE - Approve:**\n\n- Said \"Let me verify/check/investigate...\" before proceeding\n- Used Read/Grep/Bash to verify claims\n- Asked clarifying questions instead of assuming\n- No verifiable claims were made (preferences, new features, conversation)\n\n## Step 3: Respond with JSON\n\n**If you violated ANY principle:**\n\n{\"decision\": \"block\", \"reason\": \"Brief explanation of violation\", \"systemMessage\": \"⚠️ Professional honesty violation detected\"}\n\n**If you followed all principles:**\n\n{\"decision\": \"approve\", \"reason\": \"Read required files and followed all professional honesty principles\", \"systemMessage\": \"✓ Professional honesty verified\"}\n\n**CRITICAL: Be honest. If you didn't read required files OR didn't verify user claims, you MUST return decision: \"block\".**",
-            "timeout": 300
-          },
-          {
-            "type": "prompt",
-            "prompt": "# Detect Spinning Wheels\n\nYou are detecting if Claude is stuck in a loop, making things worse instead of better.\n\n## Context\n\n$ARGUMENTS\n\n## Analysis\n\nCheck if Claude is:\n1. Repeatedly attempting the same fix (3+ times)\n2. Making things worse instead of better\n3. Stuck in a loop without progress\n4. Same error appearing despite multiple \"fixes\"\n\n## Decision Criteria\n\n**Use continue:false (Hard Stop) if confidence ≥90% Claude is stuck:**\n\nPatterns:\n- Same failure 3+ times\n- Introduced new bugs while fixing original\n- No meaningful progress in 3+ attempts\n- User intervention clearly needed\n\nResponse: {\"decision\": \"block\", \"reason\": \"Stuck in loop: [pattern]\", \"continue\": false, \"stopReason\": \"I'm stuck on this issue and need your input\", \"systemMessage\": \"🔄 Loop detected: Multiple failed attempts\"}\n\n**Use decision:block if confidence 70-89% might be stuck:**\n\nResponse: {\"decision\": \"block\", \"reason\": \"Repeated attempts without clear progress\", \"systemMessage\": \"⚠️ Multiple fix attempts detected\"}\n\n**Use decision:approve if making progress:**\n\nResponse: {\"decision\": \"approve\", \"reason\": \"Systematic problem-solving with progress\", \"systemMessage\": \"✓ Debugging approach verified\"}\n\n**Key Principle: Better to stop and ask than keep making things worse.**",
-            "timeout": 300
-          },
-          {
-            "type": "prompt",
-            "prompt": "# Capture Project Learnings\n\nYou are reviewing what Claude learned during this work session.\n\n## Context\n\n$ARGUMENTS\n\n## Analysis\n\nReview the conversation. Did Claude discover:\n\n1. **Undocumented conventions** (naming, patterns, structure)\n2. **Commands** that had to be figured out\n3. **Gotchas** or edge cases\n4. **Architecture insights** that took effort to understand\n\n## Check Current Documentation\n\nBefore recommending updates, check if CLAUDE.md exists and what it contains.\n\n## Decision Criteria\n\n**Block and capture if:**\n\n- Discovered 1+ learnings worth preserving\n- Learnings are reusable (not session-specific)\n- Not already documented in CLAUDE.md\n\nResponse: {\"decision\": \"block\", \"reason\": \"Learnings to capture: [brief list]\", \"systemMessage\": \"📝 Update CLAUDE.md or .claude/rules/ with: [specific learnings]\"}\n\n**Approve if:**\n\n- No significant new learnings\n- Learnings already documented\n- Learnings are session-specific, not reusable\n\nResponse: {\"decision\": \"approve\", \"reason\": \"No new reusable learnings\", \"systemMessage\": \"✓ No memory updates needed\"}\n\n**Key Principle: Build knowledge incrementally - capture what you learn.**",
-            "timeout": 300
-          }
-        ]
-      }
-    ],
     "UserPromptSubmit": [
       {
         "hooks": [
@@ -105,17 +79,6 @@
             "type": "command",
             "command": "han checkpoint capture",
             "timeout": 30
-          }
-        ]
-      }
-    ],
-    "SubagentStop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "# Subagent Task Review\n\nYou are evaluating whether this subagent completed its assigned task correctly.\n\n## Context\n\n$ARGUMENTS\n\n## Review Checklist\n\n1. **Task Completion**: Did the subagent complete the specific task it was delegated?\n\n2. **Quality**: Was the work done to an acceptable standard?\n\n3. **Scope**: Did the subagent stay within its assigned scope?\n\n## Decision Criteria\n\n**Approve** if the subagent completed its task correctly\n**Block** if the subagent failed or deviated significantly from the task\n\nRespond with JSON: {\"decision\": \"approve\" or \"block\", \"reason\": \"brief explanation\", \"systemMessage\": \"✓ Subagent task verified\" or \"⚠️ Subagent issue detected\"}",
-            "timeout": 120
           }
         ]
       }

--- a/hashi/hashi-blueprints/hooks/hooks.json
+++ b/hashi/hashi-blueprints/hooks/hooks.json
@@ -19,17 +19,6 @@
           }
         ]
       }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "# Blueprints Documentation Check\n\nYou are verifying that blueprints/ documentation is current after implementation changes.\n\n## Context\n\n$ARGUMENTS\n\n## Review Checklist\n\n1. **Implementation Changes**: Did you make significant changes (new features, modified architecture, changed APIs, or updated system behavior)?\n\n2. **Documentation Exists**: Does a blueprints/ directory exist in this project?\n\n3. **Documentation Current**: If blueprints/ exists and changes were made, is the relevant documentation up to date?\n\n## Decision Criteria\n\n**Approve** if: No significant implementation changes, OR no blueprints/ directory, OR documentation is current\n**Block** if: Significant changes made AND blueprints/ exists AND documentation is outdated\n\nRespond with JSON: {\"decision\": \"approve\" or \"block\", \"reason\": \"your explanation\"}",
-            "timeout": 300
-          }
-        ]
-      }
     ]
   }
 }

--- a/hashi/hashi-clickup/hooks/hooks.json
+++ b/hashi/hashi-clickup/hooks/hooks.json
@@ -1,15 +1,3 @@
 {
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "# ClickUp Acceptance Criteria Validation\n\nYou are validating that ClickUp task acceptance criteria have been met.\n\n## Context\n\n$ARGUMENTS\n\n## Instructions\n\nBefore stopping, check if any ClickUp tasks (format: #ABC123 or task IDs) were mentioned or worked on in this conversation.\n\n**If ClickUp tasks were found:**\n1. Use the ClickUp MCP tools to fetch the task details\n2. Review the acceptance criteria and checklist items in the task\n3. Validate that ALL acceptance criteria have been met by the work completed\n4. If any criteria are not met, explain what remains\n\n**If no ClickUp tasks found:**\nProceed without validation.\n\nRespond with JSON: {\"decision\": \"approve\" or \"block\", \"reason\": \"your explanation\"}",
-            "timeout": 60
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/hashi/hashi-jira/hooks/hooks.json
+++ b/hashi/hashi-jira/hooks/hooks.json
@@ -1,15 +1,3 @@
 {
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "# Jira Acceptance Criteria Validation\n\nYou are validating that Jira ticket acceptance criteria have been met.\n\n## Context\n\n$ARGUMENTS\n\n## Instructions\n\nBefore stopping, check if any Jira tickets (format: ABC-123) were mentioned or worked on in this conversation.\n\n**If Jira tickets were found:**\n1. Use the Jira MCP tools to fetch the ticket details\n2. Review the acceptance criteria in the ticket\n3. Validate that ALL acceptance criteria have been met by the work completed\n4. If any criteria are not met, explain what remains\n\n**If no Jira tickets found:**\nProceed without validation.\n\nRespond with JSON: {\"decision\": \"approve\" or \"block\", \"reason\": \"your explanation\"}",
-            "timeout": 60
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/hashi/hashi-linear/hooks/hooks.json
+++ b/hashi/hashi-linear/hooks/hooks.json
@@ -1,15 +1,3 @@
 {
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "# Linear Acceptance Criteria Validation\n\nYou are validating that Linear issue acceptance criteria have been met.\n\n## Context\n\n$ARGUMENTS\n\n## Instructions\n\nBefore stopping, check if any Linear issues (format: ABC-123) were mentioned or worked on in this conversation.\n\n**If Linear issues were found:**\n1. Use the Linear MCP tools to fetch the issue details\n2. Review the acceptance criteria and requirements in the issue\n3. Validate that ALL acceptance criteria have been met by the work completed\n4. If any criteria are not met, explain what remains\n\n**If no Linear issues found:**\nProceed without validation.\n\nRespond with JSON: {\"decision\": \"approve\" or \"block\", \"reason\": \"your explanation\"}",
-            "timeout": 60
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/jutsu/jutsu-git-storytelling/hooks/hooks.json
+++ b/jutsu/jutsu-git-storytelling/hooks/hooks.json
@@ -1,15 +1,3 @@
 {
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "# Git Storytelling Assessment\n\nYou are evaluating whether Claude should commit the work from this session.\n\n## Context\n\n$ARGUMENTS\n\n## Git Storytelling Philosophy\n\nGood commit history tells the story of HOW code evolved, not just WHAT changed. Each commit should be a logical step that makes sense to a reviewer reading the history.\n\n## Assessment Criteria\n\n**Block if commits are clearly needed (high confidence):**\n- Completed feature, fix, or refactor that's ready to preserve\n- Multiple related changes that tell a coherent story\n- Significant progress that should be checkpointed\n- Work is stable and tests pass (if applicable)\n- Clear logical stopping point reached\n\n**Approve if commits not needed (or uncertain):**\n- Work is exploratory or experimental\n- Changes are incomplete or broken\n- Mid-investigation or debugging\n- User explicitly said they'll continue immediately\n- Not clear if work is at a good commit point\n\n## Decision Guidelines\n\n**Use HIGH confidence threshold:** Only block if you're 85%+ confident commits should be made. When in doubt, approve.\n\n## Response Format\n\nReturn JSON:\n\n**If commits clearly needed (block):**\n```json\n{\"decision\": \"block\", \"reason\": \"Completed work needs preservation: [summary]\", \"systemMessage\": \"📝 Commit recommended: [brief description of what to commit]\"}\n```\n\n**If commits not needed (approve):**\n```json\n{\"decision\": \"approve\", \"reason\": \"Work in progress/exploratory\", \"systemMessage\": \"✓ No commits needed\"}\n```\n\n## Commit Guidance\n\nWhen blocking, instruct Claude to:\n- **Group logically**: Related changes in same commit\n- **Tell the story**: Break complex work into multiple commits showing progression\n- **Use conventional commits**: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`\n- **Be descriptive**: Explain WHY, not just WHAT changed\n\nExample multi-commit strategy:\n1. `feat: add user authentication endpoint`\n2. `test: add authentication tests`\n3. `docs: document authentication API`",
-            "timeout": 300
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }


### PR DESCRIPTION
## Summary

- Remove all prompt hooks from plugins as they are not working correctly
- Reduces session time and token usage by eliminating non-functional hooks

## Changes

Removed prompt hooks from:
- **core/hooks/hooks.json** - Removed 4 Stop hooks and 1 SubagentStop hook
- **hashi-jira** - Removed Jira acceptance criteria validation
- **hashi-clickup** - Removed ClickUp task validation  
- **hashi-blueprints** - Removed documentation check hook
- **hashi-linear** - Removed Linear issue validation
- **jutsu-git-storytelling** - Removed commit suggestion hook

## Test plan

- [ ] Verify sessions start and stop without prompt hook errors
- [ ] Confirm reduced latency on Stop events

🤖 Generated with [Claude Code](https://claude.com/claude-code)