### PR TITLE
fix: restore memory configs in hashi plugins

### DIFF
--- a/hashi/hashi-agent-sop/han-plugin.yml
+++ b/hashi/hashi-agent-sop/han-plugin.yml
@@ -3,3 +3,19 @@
 
 # No hooks - MCP server plugins don't have validation hooks
 hooks: {}
+
+# Memory provider for team memory extraction from SOPs
+# Convention: provider name = plugin name, script = memory-provider.ts
+memory:
+  allowed_tools:
+    - mcp__plugin_hashi-agent-sop_agent-sops__list_sops
+    - mcp__plugin_hashi-agent-sop_agent-sops__get_sop
+    - mcp__plugin_hashi-agent-sop_agent-sops__search_sops
+  system_prompt: |
+    Extract observations from Standard Operating Procedures. For each item, capture:
+    - timestamp: when the SOP was created/updated
+    - summary: key workflow steps and requirements
+    - status: whether the SOP is active or deprecated
+    - type: 'sop', 'workflow', or 'procedure'
+    Focus on operational patterns, required steps, and RFC 2119 requirements.
+    Return as JSON array of observations.

--- a/hashi/hashi-blueprints/han-plugin.yml
+++ b/hashi/hashi-blueprints/han-plugin.yml
@@ -3,3 +3,18 @@
 
 # No hooks - MCP server plugins don't have validation hooks
 hooks: {}
+
+# Memory provider for team memory extraction from blueprints
+# Convention: provider name = plugin name, script = memory-provider.ts
+memory:
+  allowed_tools:
+    - mcp__plugin_hashi-blueprints_blueprints__search_blueprints
+    - mcp__plugin_hashi-blueprints_blueprints__read_blueprint
+  system_prompt: |
+    Extract observations from technical blueprints. For each item, capture:
+    - timestamp: when the blueprint was created/updated
+    - summary: key architectural decisions and patterns documented
+    - status: whether the blueprint is current or needs update
+    - type: 'blueprint', 'architecture', or 'design_decision'
+    Focus on architectural patterns, API designs, and system behaviors.
+    Return as JSON array of observations.

--- a/hashi/hashi-clickup/han-plugin.yml
+++ b/hashi/hashi-clickup/han-plugin.yml
@@ -3,3 +3,19 @@
 
 # No hooks - MCP server plugins don't have validation hooks
 hooks: {}
+
+# Memory provider for team memory extraction from ClickUp
+# Convention: provider name = plugin name, script = memory-provider.ts
+memory:
+  allowed_tools:
+    - mcp__plugin_hashi-clickup_clickup__list_tasks
+    - mcp__plugin_hashi-clickup_clickup__get_task
+    - mcp__plugin_hashi-clickup_clickup__list_spaces
+  system_prompt: |
+    Extract observations from ClickUp tasks and spaces. For each item, capture:
+    - author: ClickUp user who created/assigned
+    - timestamp: when created/updated/completed
+    - summary: task name and description highlights
+    - status: task status
+    - type: 'task', 'subtask', or 'comment'
+    Return as JSON array of observations.

--- a/hashi/hashi-figma/han-plugin.yml
+++ b/hashi/hashi-figma/han-plugin.yml
@@ -3,3 +3,20 @@
 
 # No hooks - MCP server plugins don't have validation hooks
 hooks: {}
+
+# Memory provider for team memory extraction from Figma
+# Convention: provider name = plugin name, script = memory-provider.ts
+memory:
+  allowed_tools:
+    - mcp__plugin_hashi-figma_figma__list_files
+    - mcp__plugin_hashi-figma_figma__get_file
+    - mcp__plugin_hashi-figma_figma__get_comments
+  system_prompt: |
+    Extract observations from Figma files and comments. For each item, capture:
+    - author: Figma user who created/commented
+    - timestamp: when created/updated
+    - summary: design decisions, component names, or feedback highlights
+    - status: file/component state
+    - type: 'design', 'comment', or 'component'
+    Focus on design decisions, feedback, and component documentation.
+    Return as JSON array of observations.

--- a/hashi/hashi-gitlab/han-plugin.yml
+++ b/hashi/hashi-gitlab/han-plugin.yml
@@ -3,3 +3,19 @@
 
 # No hooks - MCP server plugins don't have validation hooks
 hooks: {}
+
+# Memory provider for team memory extraction from GitLab
+# Convention: provider name = plugin name, script = memory-provider.ts
+memory:
+  allowed_tools:
+    - mcp__plugin_hashi-gitlab_gitlab__list_merge_requests
+    - mcp__plugin_hashi-gitlab_gitlab__get_merge_request
+    - mcp__plugin_hashi-gitlab_gitlab__list_issues
+  system_prompt: |
+    Extract observations from GitLab merge requests and issues. For each item, capture:
+    - author: GitLab username
+    - timestamp: when created/merged
+    - summary: title and key points from description
+    - files: list of files changed (for MRs)
+    - type: 'mr', 'review', or 'issue'
+    Return as JSON array of observations.

--- a/hashi/hashi-jira/han-plugin.yml
+++ b/hashi/hashi-jira/han-plugin.yml
@@ -3,3 +3,19 @@
 
 # No hooks - MCP server plugins don't have validation hooks
 hooks: {}
+
+# Memory provider for team memory extraction from Jira
+# Convention: provider name = plugin name, script = memory-provider.ts
+memory:
+  allowed_tools:
+    - mcp__plugin_hashi-jira_atlassian__search_issues
+    - mcp__plugin_hashi-jira_atlassian__get_issue
+    - mcp__plugin_hashi-jira_atlassian__list_projects
+  system_prompt: |
+    Extract observations from Jira tickets and projects. For each item, capture:
+    - author: Jira user (reporter or assignee)
+    - timestamp: when created/updated/resolved
+    - summary: ticket summary and key acceptance criteria
+    - status: ticket state (To Do, In Progress, Done, etc.)
+    - type: 'ticket', 'epic', or 'comment'
+    Return as JSON array of observations.

--- a/hashi/hashi-linear/han-plugin.yml
+++ b/hashi/hashi-linear/han-plugin.yml
@@ -3,3 +3,19 @@
 
 # No hooks - MCP server plugins don't have validation hooks
 hooks: {}
+
+# Memory provider for team memory extraction from Linear
+# Convention: provider name = plugin name, script = memory-provider.ts
+memory:
+  allowed_tools:
+    - mcp__plugin_hashi-linear_linear__list_issues
+    - mcp__plugin_hashi-linear_linear__get_issue
+    - mcp__plugin_hashi-linear_linear__list_projects
+  system_prompt: |
+    Extract observations from Linear issues and projects. For each item, capture:
+    - author: Linear user who created/updated
+    - timestamp: when created/updated/completed
+    - summary: issue title and description highlights
+    - status: issue state (backlog, in_progress, done, etc.)
+    - type: 'issue', 'project', or 'comment'
+    Return as JSON array of observations.

--- a/hashi/hashi-sentry/han-plugin.yml
+++ b/hashi/hashi-sentry/han-plugin.yml
@@ -3,3 +3,19 @@
 
 # No hooks - MCP server plugins don't have validation hooks
 hooks: {}
+
+# Memory provider for team memory extraction from Sentry
+# Convention: provider name = plugin name, script = memory-provider.ts
+memory:
+  allowed_tools:
+    - mcp__plugin_hashi-sentry_sentry__list_issues
+    - mcp__plugin_hashi-sentry_sentry__get_issue
+    - mcp__plugin_hashi-sentry_sentry__list_events
+  system_prompt: |
+    Extract observations from Sentry error reports and issues. For each item, capture:
+    - timestamp: when the error first/last occurred
+    - summary: error message and stack trace highlights
+    - frequency: how often this error occurs
+    - status: issue state (unresolved, resolved, ignored)
+    - type: 'error', 'issue', or 'event'
+    Focus on patterns and recurring issues. Return as JSON array of observations.


### PR DESCRIPTION
## Summary

Reverts the incorrect removal of memory configs from han-plugin.yml files in PR #23.

These configs define which MCP tools each plugin can use for memory extraction, even if the `memory-provider.ts` script doesn't exist yet. The discovery system gracefully handles missing scripts with a warning.

**Restored configs for:**
- hashi-agent-sop
- hashi-blueprints
- hashi-clickup
- hashi-figma
- hashi-gitlab
- hashi-jira
- hashi-linear
- hashi-sentry

## Test plan

- [x] All 21 memory-provider-discovery tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)