### PR TITLE
fix: respect hooks.enabled config in dispatch and add --noEmit to tsc

### DIFF
--- a/jutsu/jutsu-typescript/han-plugin.yml
+++ b/jutsu/jutsu-typescript/han-plugin.yml
@@ -1,6 +1,6 @@
 hooks:
   typecheck:
-    command: "npx -y --package typescript tsc"
+    command: "npx -y --package typescript tsc --noEmit"
     dirs_with:
       - "tsconfig.json"
     if_changed:

--- a/packages/han/lib/commands/hook/dispatch.ts
+++ b/packages/han/lib/commands/hook/dispatch.ts
@@ -9,7 +9,11 @@ import {
 	type MarketplaceConfig,
 	readSettingsFile,
 } from "../../claude-settings.ts";
-import { getHanBinary, isCheckpointsEnabled } from "../../han-settings.ts";
+import {
+	getHanBinary,
+	isCheckpointsEnabled,
+	isHooksEnabled,
+} from "../../han-settings.ts";
 import { getPluginNameFromRoot } from "../../shared.ts";
 import { recordHookExecution as recordOtelHookExecution } from "../../telemetry/index.ts";
 
@@ -496,6 +500,11 @@ function dispatchHooks(
 		process.env.HAN_DISABLE_HOOKS === "true" ||
 		process.env.HAN_DISABLE_HOOKS === "1"
 	) {
+		process.exit(0);
+	}
+
+	// Check if hooks are disabled via han.yml config
+	if (!isHooksEnabled()) {
 		process.exit(0);
 	}
 


### PR DESCRIPTION
## Summary

Two bug fixes:

1. **dispatch.ts**: Add `isHooksEnabled()` check so that `hooks.enabled: false` in `han.yml` actually disables hook dispatch. Previously only the `HAN_DISABLE_HOOKS` environment variable was checked.

2. **jutsu-typescript**: Add `--noEmit` flag to tsc command to prevent generating JS files. The typecheck hook should only validate types, not compile TypeScript to JavaScript.

## Problem

Setting `hooks.enabled: false` in `han.yml` does not disable hooks:

```yaml
# .claude/han.yml
hooks:
  enabled: false  # This was ignored!
```

Additionally, the jutsu-typescript typecheck hook was running `npx tsc` without `--noEmit`, causing it to generate `.js` files in user projects.

## Changes

- `packages/han/lib/commands/hook/dispatch.ts`: Added check for `isHooksEnabled()` after env variable check
- `jutsu/jutsu-typescript/han-plugin.yml`: Added `--noEmit` flag to tsc command

## Test plan

- [ ] Verify `hooks.enabled: false` in han.yml disables all hooks
- [ ] Verify jutsu-typescript typecheck no longer generates JS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)