### PR TITLE
Remove CORS wildcard from coordinator

### DIFF
--- a/packages/han/lib/commands/coordinator/server.ts
+++ b/packages/han/lib/commands/coordinator/server.ts
@@ -387,7 +387,6 @@ export async function startServer(
 			origin: [
 				"http://localhost:41956",
 				"https://dashboard.local.han.guru",
-				"*", // Fallback for development
 			],
 			credentials: true,
 			methods: ["GET", "POST", "OPTIONS"],


### PR DESCRIPTION
## Summary

Remove wildcard () from CORS origin configuration in coordinator GraphQL server for improved security.

## Changes

**File**: 

- Removed  from CORS origins array
- Now only allows explicit origins:
  -  (local development)  
  -  (Railway deployment)

## Security Impact

The wildcard origin allows **any website** to make authenticated requests to the coordinator GraphQL API. While the coordinator runs locally, this still poses risks:

1. **Malicious websites** could query sensitive session data
2. **CSRF attacks** possible from untrusted origins
3. **No origin validation** on mutations

## Testing

- [x] Verified dashboard loads correctly from allowed origins
- [ ] Test local development at http://localhost:41956
- [ ] Test Railway deployment at https://dashboard.local.han.guru

## Context

Addresses security recommendation from PR #26 code review. The wildcard was added as a "development fallback" but is unnecessary since we know the exact origins.

Generated with [Claude Code](https://claude.com/claude-code)