### PR TITLE
docs(ai-dlc): refine methodology for technical accuracy and scope

### DIFF
--- a/website/content/papers/ai-dlc-2026.md
+++ b/website/content/papers/ai-dlc-2026.md
@@ -493,9 +493,13 @@ The role shifts from "doing the work" to **"defining what work matters and verif
 
 However, humans remain integral. Product owners ensure alignment with business objectives. Developers maintain design quality and handle judgment calls. These roles ensure that automation and human accountability remain balanced.
 
-### Platform Agnostic
+### Tool and Platform Agnostic
 
-AI-DLC 2026 is intentionally cloud-agnostic and platform-agnostic. The methodology applies regardless of infrastructure choices:
+AI-DLC 2026 is intentionally agnostic to both tooling and infrastructure. The methodology applies regardless of which IDE, AI agent, or cloud provider you choose.
+
+**Technique over tools.** The core of AI-DLC isn't a specific product—it's the logic of how state persists across sessions, how backpressure guides iteration, and how human steering integrates with autonomous execution. These patterns work whether you're using Claude Code, Cursor, Kiro, OpenCode, or a custom agent framework. The principles transfer; the implementation details vary.
+
+**Infrastructure independence.** The methodology applies regardless of deployment choices:
 
 - **Container orchestration:** Kubernetes, ECS, Docker Swarm, Nomad
 - **Serverless:** Lambda, Cloud Functions, Azure Functions, Cloudflare Workers
@@ -503,7 +507,7 @@ AI-DLC 2026 is intentionally cloud-agnostic and platform-agnostic. The methodolo
 - **Edge:** IoT devices, edge computing platforms
 - **Hybrid:** Any combination of the above
 
-The methodology should be independent of vendor choices. Choose infrastructure based on requirements, cost constraints, and team expertise—not methodology constraints.
+Choose tools and infrastructure based on requirements, cost constraints, and team expertise—not methodology constraints.
 
 ---
 


### PR DESCRIPTION
## Summary

Refines the AI-DLC 2026 paper to improve technical accuracy and address gaps in the methodology's scope. Focuses on clarifying what enables autonomous AI workflows (orchestration, not magic) and expanding coverage to requirements phase.

## Changes

- **Clarify sustained reasoning is orchestration-based**: Reframe "multi-hour sustained reasoning" to emphasize state-persistent orchestration and task-handoff techniques rather than implying native model capability
- **Add "Beyond Code: The Requirements Silo" section**: Expand scope to address how AI should steer requirements conversations through probing questions, not just format documents
- **Soften time claims**: Change "implement a feature in minutes" to "sub-hour architectural iterations" for technical realism
- **Add "intelligence ceiling" concept**: Argue that prescriptive workflows cap AI capability; backpressure unlocks the model's ability to propose alternatives
- **Add "The Operator Multiplier" concept**: AI amplifies experience rather than equalizing it—experienced operators produce superior systems, not just more output
- **Expand "Tool and Platform Agnostic"**: Rename section and emphasize technique over tools; the core patterns transfer across any IDE or agent framework

## How It Embodies Bushido

- [x] **Honesty (誠)** - Transparent about trade-offs
- [x] **Honor (名誉)** - Maintains quality standards

## Type of Change

- [x] Documentation update

## Testing

- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings