### PR TITLE
feat(ai-dlc): complete VCS config system unit

### DIFF
--- a/.ai-dlc/vcs-strategy-config/unit-01-config-system.md
+++ b/.ai-dlc/vcs-strategy-config/unit-01-config-system.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 depends_on: []
 branch: ai-dlc/vcs-strategy-config/01-config-system
 discipline: backend
@@ -13,19 +13,19 @@ Implement the `.ai-dlc/settings.yml` configuration system with schema definition
 
 ## Discipline
 
-backend - This unit involves TypeScript/shell configuration loading and YAML parsing in the jutsu-ai-dlc plugin.
+backend - This unit involves TypeScript/shell configuration loading and YAML parsing in the ai-dlc plugin.
 
 ## Success Criteria
 
-- [ ] `.ai-dlc/settings.yml` schema defined with `git:` and `jj:` keys
-- [ ] JSON schema created at `jutsu/jutsu-ai-dlc/schemas/settings.schema.json` for editor autocomplete
-- [ ] Per-intent override supported via intent.md frontmatter `git:` / `jj:` key
-- [ ] Config loading function with precedence: intent → repo → defaults
-- [ ] Default values: `change_strategy: unit`, `elaboration_review: true`, `default_branch: auto`
+- [x] `.ai-dlc/settings.yml` schema defined with `git:` and `jj:` keys
+- [x] JSON schema created at `patterns/ai-dlc/schemas/settings.schema.json` for editor autocomplete
+- [x] Per-intent override supported via intent.md frontmatter `git:` / `jj:` key
+- [x] Config loading function with precedence: intent → repo → defaults
+- [x] Default values: `change_strategy: unit`, `elaboration_review: true`, `default_branch: auto`
 
 ## Notes
 
-- Create `jutsu/jutsu-ai-dlc/lib/config.ts` for TypeScript config loading
-- Create `jutsu/jutsu-ai-dlc/lib/config.sh` for shell script config loading (used by dag.sh)
-- JSON schema should be referenced in settings.yml via `$schema` comment
-- Consider using `yaml` package for parsing (already used elsewhere in han)
+- `patterns/ai-dlc/lib/config.ts` - TypeScript config loading with `getMergedSettings()`
+- `patterns/ai-dlc/lib/config.sh` - Shell script config loading with `get_ai_dlc_config()`
+- JSON schema referenced via `$id` at `https://han.guru/schemas/ai-dlc-settings.schema.json`
+- Uses `han parse yaml` for YAML parsing consistency between TypeScript and shell


### PR DESCRIPTION
## Summary

Implements unit-01-config-system for the vcs-strategy-config AI-DLC intent.

This unit marks the existing config system implementation as complete and updates the unit status.

### Changes
- Updated unit-01-config-system.md status to `completed`
- Updated success criteria checkboxes
- Corrected file locations from `jutsu/jutsu-ai-dlc/` to `patterns/ai-dlc/`

### Existing Implementation Verified
The config system was already implemented at `patterns/ai-dlc/lib/`:
- `config.ts` - TypeScript config loading with precedence handling
- `config.sh` - Shell script config loading (sourced by dag.sh)
- `schemas/settings.schema.json` - JSON Schema for editor autocomplete

### Success Criteria (All Satisfied)
- [x] `.ai-dlc/settings.yml` schema with `git:` and `jj:` keys
- [x] JSON schema for editor autocomplete
- [x] Per-intent override via intent.md frontmatter
- [x] Config loading with precedence: intent → repo → defaults
- [x] Default values: `change_strategy: unit`, `elaboration_review: true`, `default_branch: auto`

---
🤖 Generated by AI-DLC workflow