### PR TITLE
feat: add Svelte Flow plugin for node-based editors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1139,6 +1139,25 @@
       ]
     },
     {
+      "name": "svelteflow",
+      "description": "Build node-based editors, interactive diagrams, and workflow builders with Svelte Flow.",
+      "source": "./frameworks/svelteflow",
+      "category": "Framework",
+      "keywords": [
+        "svelteflow",
+        "svelte-flow",
+        "node-based",
+        "diagram",
+        "flowchart",
+        "workflow",
+        "graph",
+        "editor",
+        "svelte",
+        "typescript",
+        "interactive"
+      ]
+    },
+    {
       "name": "reddit",
       "description": "MCP server for Reddit integration providing frontpage posts, subreddit information, hot/new/top/rising posts, and comment retrieval via uvx mcp-server-reddit.",
       "source": "./plugins/services/reddit",

--- a/frameworks/svelteflow/.claude-plugin/plugin.json
+++ b/frameworks/svelteflow/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "svelteflow",
+  "version": "1.0.0",
+  "description": "Build node-based editors, interactive diagrams, and workflow builders with Svelte Flow.",
+  "author": {
+    "name": "The Bushido Collective",
+    "url": "https://thebushido.co"
+  },
+  "homepage": "https://svelteflow.dev",
+  "repository": "https://github.com/thebushidocollective/han",
+  "license": "Apache-2.0",
+  "keywords": [
+    "svelteflow",
+    "svelte-flow",
+    "node-based",
+    "diagram",
+    "flowchart",
+    "workflow",
+    "graph",
+    "editor",
+    "svelte",
+    "typescript",
+    "interactive"
+  ]
+}

--- a/frameworks/svelteflow/skills/svelteflow-custom-nodes/SKILL.md
+++ b/frameworks/svelteflow/skills/svelteflow-custom-nodes/SKILL.md
@@ -1,0 +1,687 @@
+---
+name: svelteflow-custom-nodes
+description: Use when creating custom Svelte Flow nodes, edges, and handles. Covers custom node components, resizable nodes, toolbars, and advanced customization.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Svelte Flow Custom Nodes and Edges
+
+Create fully customized nodes and edges with Svelte Flow. Build complex
+node-based editors with custom styling, behaviors, and interactions.
+
+## Custom Node Component
+
+```svelte
+<!-- TextUpdaterNode.svelte -->
+<script lang="ts">
+  import { Handle, Position } from '@xyflow/svelte';
+
+  export let id: string;
+  export let data: { label: string };
+  export let isConnectable: boolean;
+
+  function handleChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    // Dispatch custom event or update store
+    console.log('Value changed:', target.value);
+  }
+</script>
+
+<div class="text-updater-node">
+  <Handle type="target" position={Position.Top} {isConnectable} />
+
+  <div class="content">
+    <label for="text">Text:</label>
+    <input
+      id="text"
+      name="text"
+      on:input={handleChange}
+      class="nodrag"
+      value={data.label}
+    />
+  </div>
+
+  <Handle type="source" position={Position.Bottom} id="a" {isConnectable} />
+</div>
+
+<style>
+  .text-updater-node {
+    background: white;
+    border: 1px solid #1a192b;
+    border-radius: 8px;
+    padding: 10px;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  input {
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+</style>
+```
+
+## Registering Custom Nodes
+
+```svelte
+<!-- Flow.svelte -->
+<script lang="ts">
+  import { SvelteFlow, type Node, type NodeTypes } from '@xyflow/svelte';
+  import { writable } from 'svelte/store';
+  import TextUpdaterNode from './TextUpdaterNode.svelte';
+  import ColorPickerNode from './ColorPickerNode.svelte';
+
+  // Define node types
+  const nodeTypes: NodeTypes = {
+    textUpdater: TextUpdaterNode,
+    colorPicker: ColorPickerNode,
+  };
+
+  const nodes = writable<Node[]>([
+    {
+      id: '1',
+      type: 'textUpdater',
+      position: { x: 0, y: 0 },
+      data: { label: 'Hello' },
+    },
+    {
+      id: '2',
+      type: 'colorPicker',
+      position: { x: 200, y: 100 },
+      data: { color: '#ff0000' },
+    },
+  ]);
+
+  const edges = writable([]);
+</script>
+
+<SvelteFlow {nodes} {edges} {nodeTypes} fitView />
+```
+
+## Styled Node with Tailwind
+
+```svelte
+<!-- StatusNode.svelte -->
+<script lang="ts">
+  import { Handle, Position } from '@xyflow/svelte';
+
+  export let data: {
+    label: string;
+    status: 'pending' | 'running' | 'completed' | 'error';
+  };
+
+  const statusConfig = {
+    pending: { bg: 'bg-yellow-100', border: 'border-yellow-400', icon: '⏳' },
+    running: { bg: 'bg-blue-100', border: 'border-blue-400', icon: '⚡' },
+    completed: { bg: 'bg-green-100', border: 'border-green-400', icon: '✅' },
+    error: { bg: 'bg-red-100', border: 'border-red-400', icon: '❌' },
+  };
+
+  $: config = statusConfig[data.status];
+</script>
+
+<div class="px-4 py-2 rounded-lg border-2 shadow-sm {config.bg} {config.border}">
+  <Handle type="target" position={Position.Top} class="!bg-gray-400" />
+
+  <div class="flex items-center gap-2">
+    <span class="text-xl">{config.icon}</span>
+    <span class="font-medium">{data.label}</span>
+  </div>
+
+  <Handle type="source" position={Position.Bottom} class="!bg-gray-400" />
+</div>
+```
+
+## Node with Multiple Handles
+
+```svelte
+<!-- SwitchNode.svelte -->
+<script lang="ts">
+  import { Handle, Position } from '@xyflow/svelte';
+
+  export let data: {
+    label: string;
+    cases: string[];
+  };
+</script>
+
+<div class="switch-node">
+  <Handle type="target" position={Position.Top} id="input" />
+
+  <div class="header">{data.label}</div>
+
+  <div class="cases">
+    {#each data.cases as caseLabel, index}
+      <div class="case">
+        {caseLabel}
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="case-{index}"
+          style="top: {30 + index * 28}px"
+        />
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .switch-node {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    padding: 12px;
+    min-width: 150px;
+  }
+
+  .header {
+    font-weight: bold;
+    text-align: center;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 8px;
+    margin-bottom: 8px;
+  }
+
+  .cases {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .case {
+    position: relative;
+    font-size: 14px;
+    text-align: right;
+    padding-right: 16px;
+  }
+</style>
+```
+
+## Resizable Node
+
+```svelte
+<!-- ResizableNode.svelte -->
+<script lang="ts">
+  import { Handle, Position, NodeResizer } from '@xyflow/svelte';
+
+  export let id: string;
+  export let data: { label: string; content: string };
+  export let selected: boolean;
+</script>
+
+<NodeResizer
+  color="#ff0071"
+  isVisible={selected}
+  minWidth={100}
+  minHeight={50}
+  handleStyle={{ width: '8px', height: '8px' }}
+/>
+
+<Handle type="target" position={Position.Top} />
+
+<div class="content">
+  <div class="label">{data.label}</div>
+  <div class="body">{data.content}</div>
+</div>
+
+<Handle type="source" position={Position.Bottom} />
+
+<style>
+  .content {
+    padding: 16px;
+    height: 100%;
+    background: white;
+    border: 1px solid #1a192b;
+    border-radius: 8px;
+  }
+
+  .label {
+    font-weight: bold;
+    margin-bottom: 8px;
+  }
+
+  .body {
+    font-size: 14px;
+    color: #666;
+  }
+</style>
+```
+
+## Node with Toolbar
+
+```svelte
+<!-- EditableNode.svelte -->
+<script lang="ts">
+  import { Handle, Position, NodeToolbar, useSvelteFlow } from '@xyflow/svelte';
+  import { createEventDispatcher } from 'svelte';
+
+  export let id: string;
+  export let data: { label: string };
+  export let selected: boolean;
+
+  const { setNodes, deleteElements } = useSvelteFlow();
+  const dispatch = createEventDispatcher();
+
+  let isEditing = false;
+  let editValue = data.label;
+
+  function handleEdit() {
+    isEditing = true;
+  }
+
+  function handleSave() {
+    setNodes((nodes) =>
+      nodes.map((node) =>
+        node.id === id
+          ? { ...node, data: { ...node.data, label: editValue } }
+          : node
+      )
+    );
+    isEditing = false;
+  }
+
+  function handleDelete() {
+    deleteElements({ nodes: [{ id }] });
+  }
+</script>
+
+<NodeToolbar isVisible={selected} position={Position.Top}>
+  <button on:click={handleEdit} class="toolbar-btn">✏️ Edit</button>
+  <button on:click={handleDelete} class="toolbar-btn delete">🗑️ Delete</button>
+</NodeToolbar>
+
+<Handle type="target" position={Position.Top} />
+
+<div class="node-content">
+  {#if isEditing}
+    <div class="edit-form">
+      <input bind:value={editValue} class="nodrag" />
+      <button on:click={handleSave}>Save</button>
+    </div>
+  {:else}
+    <span>{data.label}</span>
+  {/if}
+</div>
+
+<Handle type="source" position={Position.Bottom} />
+
+<style>
+  .node-content {
+    padding: 12px 16px;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  .toolbar-btn {
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: white;
+    cursor: pointer;
+  }
+
+  .toolbar-btn.delete {
+    color: #dc2626;
+  }
+
+  .edit-form {
+    display: flex;
+    gap: 8px;
+  }
+
+  input {
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+</style>
+```
+
+## Custom Edge
+
+```svelte
+<!-- ButtonEdge.svelte -->
+<script lang="ts">
+  import {
+    BaseEdge,
+    EdgeLabelRenderer,
+    getBezierPath,
+    useSvelteFlow,
+  } from '@xyflow/svelte';
+
+  export let id: string;
+  export let sourceX: number;
+  export let sourceY: number;
+  export let targetX: number;
+  export let targetY: number;
+  export let sourcePosition: Position;
+  export let targetPosition: Position;
+  export let style: string = '';
+  export let markerEnd: string = '';
+
+  const { setEdges } = useSvelteFlow();
+
+  $: [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  function handleClick() {
+    setEdges((edges) => edges.filter((edge) => edge.id !== id));
+  }
+</script>
+
+<BaseEdge path={edgePath} {markerEnd} {style} />
+<EdgeLabelRenderer>
+  <div
+    style="
+      position: absolute;
+      transform: translate(-50%, -50%) translate({labelX}px, {labelY}px);
+      pointer-events: all;
+    "
+    class="nodrag nopan"
+  >
+    <button class="delete-button" on:click={handleClick}>×</button>
+  </div>
+</EdgeLabelRenderer>
+
+<style>
+  .delete-button {
+    width: 20px;
+    height: 20px;
+    background: #f0f0f0;
+    border-radius: 50%;
+    border: 1px solid #999;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .delete-button:hover {
+    background: #ffcccc;
+  }
+</style>
+```
+
+## Registering Custom Edges
+
+```svelte
+<script lang="ts">
+  import { SvelteFlow, type EdgeTypes } from '@xyflow/svelte';
+  import { writable } from 'svelte/store';
+  import ButtonEdge from './ButtonEdge.svelte';
+  import AnimatedEdge from './AnimatedEdge.svelte';
+
+  const edgeTypes: EdgeTypes = {
+    buttonEdge: ButtonEdge,
+    animated: AnimatedEdge,
+  };
+
+  const edges = writable([
+    {
+      id: 'e1-2',
+      source: '1',
+      target: '2',
+      type: 'buttonEdge',
+    },
+  ]);
+</script>
+
+<SvelteFlow {nodes} {edges} {edgeTypes} />
+```
+
+## Group Node (Parent Container)
+
+```svelte
+<!-- GroupNode.svelte -->
+<script lang="ts">
+  export let data: { label: string };
+</script>
+
+<div class="group-node">
+  <div class="group-label">{data.label}</div>
+</div>
+
+<style>
+  .group-node {
+    padding: 8px;
+    border: 2px dashed #999;
+    border-radius: 8px;
+    background: rgba(240, 240, 240, 0.5);
+    min-width: 200px;
+    min-height: 150px;
+  }
+
+  .group-label {
+    font-size: 12px;
+    color: #666;
+    font-weight: 500;
+  }
+</style>
+```
+
+```svelte
+<!-- Usage with child nodes -->
+<script>
+  const nodes = writable([
+    {
+      id: 'group-1',
+      type: 'group',
+      data: { label: 'Group A' },
+      position: { x: 0, y: 0 },
+      style: 'width: 300px; height: 200px;',
+    },
+    {
+      id: 'child-1',
+      data: { label: 'Child Node' },
+      position: { x: 50, y: 50 },
+      parentId: 'group-1',
+      extent: 'parent',
+    },
+  ]);
+</script>
+```
+
+## Custom Handle Component
+
+```svelte
+<!-- CustomHandle.svelte -->
+<script lang="ts">
+  import { Handle } from '@xyflow/svelte';
+
+  export let type: 'source' | 'target';
+  export let position: Position;
+  export let id: string = '';
+  export let isConnectable: boolean = true;
+  export let color: string = '#555';
+</script>
+
+<Handle
+  {type}
+  {position}
+  {id}
+  {isConnectable}
+  style="
+    width: 12px;
+    height: 12px;
+    background: {color};
+    border: 2px solid white;
+  "
+/>
+```
+
+## Interactive Node with State
+
+```svelte
+<!-- CounterNode.svelte -->
+<script lang="ts">
+  import { Handle, Position, useSvelteFlow } from '@xyflow/svelte';
+
+  export let id: string;
+  export let data: { count: number };
+
+  const { setNodes } = useSvelteFlow();
+
+  function increment() {
+    setNodes((nodes) =>
+      nodes.map((node) =>
+        node.id === id
+          ? { ...node, data: { ...node.data, count: node.data.count + 1 } }
+          : node
+      )
+    );
+  }
+
+  function decrement() {
+    setNodes((nodes) =>
+      nodes.map((node) =>
+        node.id === id
+          ? { ...node, data: { ...node.data, count: node.data.count - 1 } }
+          : node
+      )
+    );
+  }
+</script>
+
+<div class="counter-node">
+  <Handle type="target" position={Position.Top} />
+
+  <div class="display">{data.count}</div>
+
+  <div class="buttons">
+    <button on:click={decrement} class="nodrag">-</button>
+    <button on:click={increment} class="nodrag">+</button>
+  </div>
+
+  <Handle type="source" position={Position.Bottom} />
+</div>
+
+<style>
+  .counter-node {
+    background: white;
+    border: 2px solid #1a192b;
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+  }
+
+  .display {
+    font-size: 32px;
+    font-weight: bold;
+    margin: 8px 0;
+  }
+
+  .buttons {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+  }
+
+  button {
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: 50%;
+    background: #1a192b;
+    color: white;
+    font-size: 18px;
+    cursor: pointer;
+  }
+
+  button:hover {
+    background: #333;
+  }
+</style>
+```
+
+## CSS Styling
+
+```css
+/* Global flow styles */
+:global(.svelte-flow__node-custom) {
+  background: white;
+  border: 1px solid #1a192b;
+  border-radius: 8px;
+  padding: 10px;
+  font-size: 12px;
+}
+
+:global(.svelte-flow__node-custom.selected) {
+  border-color: #ff0071;
+  box-shadow: 0 0 0 2px #ff0071;
+}
+
+:global(.svelte-flow__handle) {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: #555;
+}
+
+:global(.svelte-flow__handle-connecting) {
+  background-color: #ff0071;
+}
+
+:global(.svelte-flow__handle-valid) {
+  background-color: #55dd99;
+}
+
+/* Prevent drag on interactive elements */
+:global(.nodrag) {
+  pointer-events: all;
+}
+
+/* Edge styling */
+:global(.svelte-flow__edge-path) {
+  stroke: #b1b1b7;
+  stroke-width: 2;
+}
+
+:global(.svelte-flow__edge.selected .svelte-flow__edge-path) {
+  stroke: #ff0071;
+}
+```
+
+## When to Use This Skill
+
+Use svelteflow-custom-nodes when you need to:
+
+- Build nodes with interactive Svelte components
+- Create visually distinct node types
+- Add node toolbars and context menus
+- Build resizable nodes
+- Create group/container nodes
+- Add custom edge interactions
+- Build complex workflow interfaces in Svelte
+
+## Best Practices
+
+- Use Svelte's reactivity for state management
+- Define nodeTypes/edgeTypes at component level
+- Use the `nodrag` class on interactive elements
+- Keep node components focused and reusable
+- Use TypeScript for type-safe node data
+- Use CSS scoping for node styles
+- Test connection validation thoroughly
+
+## Resources
+
+- [Svelte Flow Custom Nodes](https://svelteflow.dev/learn/customization/custom-nodes)
+- [Svelte Flow Custom Edges](https://svelteflow.dev/learn/customization/custom-edges)
+- [Node Toolbar API](https://svelteflow.dev/api-reference/components/node-toolbar)
+- [Node Resizer API](https://svelteflow.dev/api-reference/components/node-resizer)

--- a/frameworks/svelteflow/skills/svelteflow-fundamentals/SKILL.md
+++ b/frameworks/svelteflow/skills/svelteflow-fundamentals/SKILL.md
@@ -1,0 +1,569 @@
+---
+name: svelteflow-fundamentals
+description: Use when building node-based UIs, flow diagrams, workflow editors, or interactive graphs with Svelte Flow. Covers setup, nodes, edges, controls, and interactivity.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Svelte Flow Fundamentals
+
+Build customizable node-based editors and interactive diagrams with Svelte Flow.
+This skill covers core concepts, setup, and common patterns for creating
+flow-based interfaces in Svelte applications.
+
+## Installation
+
+```bash
+# npm
+npm install @xyflow/svelte
+
+# pnpm
+pnpm add @xyflow/svelte
+
+# yarn
+yarn add @xyflow/svelte
+```
+
+## Basic Setup
+
+```svelte
+<script lang="ts">
+  import {
+    SvelteFlow,
+    Controls,
+    Background,
+    MiniMap,
+    type Node,
+    type Edge,
+  } from '@xyflow/svelte';
+  import { writable } from 'svelte/store';
+
+  import '@xyflow/svelte/dist/style.css';
+
+  const nodes = writable<Node[]>([
+    {
+      id: '1',
+      type: 'input',
+      data: { label: 'Start' },
+      position: { x: 250, y: 0 },
+    },
+    {
+      id: '2',
+      data: { label: 'Process' },
+      position: { x: 250, y: 100 },
+    },
+    {
+      id: '3',
+      type: 'output',
+      data: { label: 'End' },
+      position: { x: 250, y: 200 },
+    },
+  ]);
+
+  const edges = writable<Edge[]>([
+    { id: 'e1-2', source: '1', target: '2' },
+    { id: 'e2-3', source: '2', target: '3' },
+  ]);
+</script>
+
+<div style="height: 100vh; width: 100vw;">
+  <SvelteFlow {nodes} {edges} fitView>
+    <Controls />
+    <Background />
+    <MiniMap />
+  </SvelteFlow>
+</div>
+```
+
+## Using Stores for State
+
+```svelte
+<script lang="ts">
+  import { SvelteFlow, type Node, type Edge } from '@xyflow/svelte';
+  import { writable, derived } from 'svelte/store';
+
+  // Writable stores for reactive state
+  const nodes = writable<Node[]>([
+    { id: '1', data: { label: 'Node 1' }, position: { x: 0, y: 0 } },
+    { id: '2', data: { label: 'Node 2' }, position: { x: 200, y: 100 } },
+  ]);
+
+  const edges = writable<Edge[]>([
+    { id: 'e1-2', source: '1', target: '2' },
+  ]);
+
+  // Derived store for computed values
+  const nodeCount = derived(nodes, ($nodes) => $nodes.length);
+  const edgeCount = derived(edges, ($edges) => $edges.length);
+
+  // Add a new node
+  function addNode() {
+    const id = `node-${Date.now()}`;
+    nodes.update((n) => [
+      ...n,
+      {
+        id,
+        data: { label: `Node ${$nodeCount + 1}` },
+        position: { x: Math.random() * 300, y: Math.random() * 300 },
+      },
+    ]);
+  }
+
+  // Update node data
+  function updateNodeLabel(id: string, label: string) {
+    nodes.update((n) =>
+      n.map((node) =>
+        node.id === id ? { ...node, data: { ...node.data, label } } : node
+      )
+    );
+  }
+
+  // Delete a node
+  function deleteNode(id: string) {
+    nodes.update((n) => n.filter((node) => node.id !== id));
+    // Also remove connected edges
+    edges.update((e) => e.filter((edge) => edge.source !== id && edge.target !== id));
+  }
+</script>
+
+<div>
+  <p>Nodes: {$nodeCount} | Edges: {$edgeCount}</p>
+  <button on:click={addNode}>Add Node</button>
+</div>
+
+<SvelteFlow {nodes} {edges} fitView />
+```
+
+## Node Types
+
+### Built-in Node Types
+
+```svelte
+<script lang="ts">
+  import { SvelteFlow, type Node } from '@xyflow/svelte';
+  import { writable } from 'svelte/store';
+
+  const nodes = writable<Node[]>([
+    // Input node - only has source handles
+    {
+      id: '1',
+      type: 'input',
+      data: { label: 'Input Node' },
+      position: { x: 0, y: 0 },
+    },
+    // Default node - has both source and target handles
+    {
+      id: '2',
+      type: 'default',
+      data: { label: 'Default Node' },
+      position: { x: 0, y: 100 },
+    },
+    // Output node - only has target handles
+    {
+      id: '3',
+      type: 'output',
+      data: { label: 'Output Node' },
+      position: { x: 0, y: 200 },
+    },
+  ]);
+</script>
+```
+
+### Node Configuration
+
+```typescript
+import { Position, type Node } from '@xyflow/svelte';
+
+const node: Node = {
+  id: 'unique-id',
+  type: 'default',
+  position: { x: 100, y: 100 },
+  data: { label: 'My Node', customProp: 'value' },
+  // Optional properties
+  style: 'background-color: #f0f0f0;',
+  class: 'custom-node',
+  sourcePosition: Position.Right,
+  targetPosition: Position.Left,
+  draggable: true,
+  selectable: true,
+  connectable: true,
+  deletable: true,
+  hidden: false,
+  selected: false,
+  dragging: false,
+  zIndex: 0,
+  extent: 'parent',
+  parentId: 'parent-node-id',
+  expandParent: true,
+};
+```
+
+## Edge Types and Configuration
+
+```svelte
+<script lang="ts">
+  import { SvelteFlow, MarkerType, type Edge } from '@xyflow/svelte';
+  import { writable } from 'svelte/store';
+
+  const edges = writable<Edge[]>([
+    // Default edge (bezier curve)
+    {
+      id: 'e1',
+      source: '1',
+      target: '2',
+      type: 'default',
+    },
+    // Straight line
+    {
+      id: 'e2',
+      source: '2',
+      target: '3',
+      type: 'straight',
+    },
+    // Step edge (right angles)
+    {
+      id: 'e3',
+      source: '3',
+      target: '4',
+      type: 'step',
+    },
+    // Smoothstep edge (rounded corners)
+    {
+      id: 'e4',
+      source: '4',
+      target: '5',
+      type: 'smoothstep',
+    },
+    // Styled edge with arrow
+    {
+      id: 'e5',
+      source: '5',
+      target: '6',
+      label: 'Connection',
+      style: 'stroke: #333; stroke-width: 2px;',
+      animated: true,
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color: '#333',
+      },
+    },
+  ]);
+</script>
+```
+
+## Event Handling
+
+```svelte
+<script lang="ts">
+  import { SvelteFlow, type Node, type Edge } from '@xyflow/svelte';
+  import { writable } from 'svelte/store';
+
+  const nodes = writable<Node[]>([]);
+  const edges = writable<Edge[]>([]);
+
+  // Node events
+  function handleNodeClick(event: CustomEvent<{ node: Node }>) {
+    console.log('Node clicked:', event.detail.node);
+  }
+
+  function handleNodeDoubleClick(event: CustomEvent<{ node: Node }>) {
+    console.log('Node double clicked:', event.detail.node);
+  }
+
+  function handleNodeDragStart(event: CustomEvent<{ node: Node }>) {
+    console.log('Drag started:', event.detail.node.id);
+  }
+
+  function handleNodeDragStop(event: CustomEvent<{ node: Node }>) {
+    console.log('Drag stopped:', event.detail.node.position);
+  }
+
+  // Edge events
+  function handleEdgeClick(event: CustomEvent<{ edge: Edge }>) {
+    console.log('Edge clicked:', event.detail.edge);
+  }
+
+  // Connection events
+  function handleConnect(event: CustomEvent<{ connection: any }>) {
+    const { connection } = event.detail;
+    edges.update((e) => [
+      ...e,
+      {
+        id: `${connection.source}-${connection.target}`,
+        source: connection.source,
+        target: connection.target,
+      },
+    ]);
+  }
+
+  // Selection events
+  function handleSelectionChange(
+    event: CustomEvent<{ nodes: Node[]; edges: Edge[] }>
+  ) {
+    console.log('Selected nodes:', event.detail.nodes);
+    console.log('Selected edges:', event.detail.edges);
+  }
+</script>
+
+<SvelteFlow
+  {nodes}
+  {edges}
+  on:nodeclick={handleNodeClick}
+  on:nodedoubleclick={handleNodeDoubleClick}
+  on:nodedragstart={handleNodeDragStart}
+  on:nodedragstop={handleNodeDragStop}
+  on:edgeclick={handleEdgeClick}
+  on:connect={handleConnect}
+  on:selectionchange={handleSelectionChange}
+  fitView
+/>
+```
+
+## Plugin Components
+
+### Background
+
+```svelte
+<script>
+  import { SvelteFlow, Background, BackgroundVariant } from '@xyflow/svelte';
+</script>
+
+<SvelteFlow {nodes} {edges}>
+  <!-- Dots pattern -->
+  <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
+
+  <!-- Lines pattern -->
+  <Background variant={BackgroundVariant.Lines} gap={20} />
+
+  <!-- Cross pattern -->
+  <Background variant={BackgroundVariant.Cross} gap={25} />
+
+  <!-- Custom color -->
+  <Background color="#aaa" gap={16} />
+</SvelteFlow>
+```
+
+### Controls
+
+```svelte
+<script>
+  import { SvelteFlow, Controls } from '@xyflow/svelte';
+</script>
+
+<SvelteFlow {nodes} {edges}>
+  <Controls
+    showZoom={true}
+    showFitView={true}
+    showInteractive={true}
+    position="bottom-left"
+  />
+</SvelteFlow>
+```
+
+### MiniMap
+
+```svelte
+<script>
+  import { SvelteFlow, MiniMap } from '@xyflow/svelte';
+</script>
+
+<SvelteFlow {nodes} {edges}>
+  <MiniMap
+    nodeColor={(node) => {
+      switch (node.type) {
+        case 'input':
+          return '#0041d0';
+        case 'output':
+          return '#ff0072';
+        default:
+          return '#1a192b';
+      }
+    }}
+    nodeStrokeWidth={3}
+    zoomable
+    pannable
+  />
+</SvelteFlow>
+```
+
+### Panel
+
+```svelte
+<script>
+  import { SvelteFlow, Panel } from '@xyflow/svelte';
+</script>
+
+<SvelteFlow {nodes} {edges}>
+  <Panel position="top-left">
+    <button on:click={saveFlow}>Save</button>
+    <button on:click={restoreFlow}>Restore</button>
+  </Panel>
+
+  <Panel position="top-right">
+    <p>Node count: {$nodes.length}</p>
+  </Panel>
+</SvelteFlow>
+```
+
+## Viewport Control with useSvelteFlow
+
+```svelte
+<script lang="ts">
+  import { SvelteFlow, useSvelteFlow, Panel } from '@xyflow/svelte';
+
+  const { zoomIn, zoomOut, fitView, setCenter, getViewport } = useSvelteFlow();
+
+  function handleFitView() {
+    fitView({ padding: 0.2 });
+  }
+
+  function handleCenter() {
+    setCenter(0, 0, { zoom: 1 });
+  }
+
+  function logViewport() {
+    const viewport = getViewport();
+    console.log('Current viewport:', viewport);
+  }
+</script>
+
+<SvelteFlow {nodes} {edges}>
+  <Panel position="top-left">
+    <button on:click={() => zoomIn()}>Zoom In</button>
+    <button on:click={() => zoomOut()}>Zoom Out</button>
+    <button on:click={handleFitView}>Fit View</button>
+    <button on:click={handleCenter}>Center</button>
+    <button on:click={logViewport}>Log Viewport</button>
+  </Panel>
+</SvelteFlow>
+```
+
+## Node Operations
+
+```svelte
+<script lang="ts">
+  import { SvelteFlow, useSvelteFlow, type Node } from '@xyflow/svelte';
+  import { writable } from 'svelte/store';
+
+  const nodes = writable<Node[]>([]);
+  const edges = writable<Edge[]>([]);
+
+  const { getNodes, setNodes, addNodes, deleteElements } = useSvelteFlow();
+
+  function addNewNode() {
+    const id = `node-${Date.now()}`;
+    addNodes([
+      {
+        id,
+        data: { label: 'New Node' },
+        position: { x: Math.random() * 300, y: Math.random() * 300 },
+      },
+    ]);
+  }
+
+  function deleteSelectedNodes() {
+    const selectedNodes = getNodes().filter((node) => node.selected);
+    deleteElements({ nodes: selectedNodes });
+  }
+
+  function updateAllLabels(prefix: string) {
+    setNodes((nodes) =>
+      nodes.map((node, index) => ({
+        ...node,
+        data: { ...node.data, label: `${prefix} ${index + 1}` },
+      }))
+    );
+  }
+</script>
+```
+
+## Saving and Restoring State
+
+```svelte
+<script lang="ts">
+  import { SvelteFlow, useSvelteFlow, Panel, type Viewport } from '@xyflow/svelte';
+  import { writable, get } from 'svelte/store';
+
+  const nodes = writable<Node[]>([]);
+  const edges = writable<Edge[]>([]);
+
+  const { toObject, setViewport } = useSvelteFlow();
+
+  function saveFlow() {
+    const flow = toObject();
+    localStorage.setItem('flow', JSON.stringify(flow));
+    console.log('Flow saved');
+  }
+
+  function restoreFlow() {
+    const saved = localStorage.getItem('flow');
+    if (saved) {
+      const flow = JSON.parse(saved);
+      nodes.set(flow.nodes || []);
+      edges.set(flow.edges || []);
+      if (flow.viewport) {
+        setViewport(flow.viewport);
+      }
+      console.log('Flow restored');
+    }
+  }
+</script>
+
+<SvelteFlow {nodes} {edges}>
+  <Panel position="top-right">
+    <button on:click={saveFlow}>Save</button>
+    <button on:click={restoreFlow}>Restore</button>
+  </Panel>
+</SvelteFlow>
+```
+
+## Connection Validation
+
+```svelte
+<script lang="ts">
+  import { SvelteFlow, type IsValidConnection } from '@xyflow/svelte';
+
+  const isValidConnection: IsValidConnection = (connection) => {
+    // Prevent self-connections
+    if (connection.source === connection.target) {
+      return false;
+    }
+
+    // Add custom validation logic
+    return true;
+  };
+</script>
+
+<SvelteFlow {nodes} {edges} {isValidConnection} />
+```
+
+## When to Use This Skill
+
+Use svelteflow-fundamentals when you need to:
+
+- Build workflow builders with Svelte
+- Create data pipeline visualizations
+- Design state machine diagrams
+- Build chatbot conversation flows
+- Create organizational charts
+- Build ML pipeline visualizers
+- Create interactive decision trees in Svelte apps
+
+## Best Practices
+
+- Use Svelte stores for reactive flow state
+- Keep node components focused and reusable
+- Use TypeScript for type safety
+- Memoize expensive computations in derived stores
+- Use CSS variables for theming
+- Add keyboard shortcuts for power users
+- Implement undo/redo for better UX
+- Use fitView() on initial render
+
+## Resources
+
+- [Svelte Flow Documentation](https://svelteflow.dev/learn)
+- [Svelte Flow Examples](https://svelteflow.dev/examples)
+- [Svelte Flow API Reference](https://svelteflow.dev/api-reference)
+- [xyflow GitHub](https://github.com/xyflow/xyflow)


### PR DESCRIPTION
## Summary

- Add a new framework plugin for [Svelte Flow](https://svelteflow.dev/)
- Include skills for fundamentals (setup, nodes, edges, stores, events)
- Include skills for custom nodes and edges

## Features

Svelte Flow enables building:
- Workflow builders with Svelte
- Data pipeline visualizations
- State machine diagrams
- Chatbot conversation flows
- Interactive decision trees
- ML pipeline visualizers

## Skills

1. **svelteflow-fundamentals**: Core concepts, setup with Svelte stores, nodes, edges, plugin components (Background, Controls, MiniMap, Panel), event handling, viewport control, and state management
2. **svelteflow-custom-nodes**: Custom node components in Svelte, styled nodes, resizable nodes, node toolbars, custom edges, and connection validation

## Notes

- Svelte Flow is the Svelte counterpart to React Flow, built by the same xyflow team
- Both libraries share similar APIs but are optimized for their respective frameworks

## Test plan

- [ ] Verify plugin validates with `claude plugin validate frameworks/svelteflow`
- [ ] Verify website builds successfully
- [ ] Test skills are discoverable in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)