### PR TITLE
fix(sentiment): exclude env vars from ALL CAPS frustration detection

### DIFF
--- a/packages/han-native/src/sentiment.rs
+++ b/packages/han-native/src/sentiment.rs
@@ -9,7 +9,17 @@ use serde::{Deserialize, Serialize};
 use vader_sentiment::SentimentIntensityAnalyzer;
 
 // Pre-compiled regexes - compiled once at startup, None if compilation fails
-static CAPS_REGEX: Lazy<Option<Regex>> = Lazy::new(|| Regex::new(r"[A-Z]{5,}").ok());
+//
+// CAPS_REGEX: Match 5+ consecutive uppercase letters as word (with boundaries)
+// Used as fallback when consecutive caps word detection doesn't trigger.
+// Note: Single acronyms (HTTPS, README) won't trigger frustration because we
+// require 2+ consecutive ALL CAPS words for detection. This regex is only used
+// as a fallback for single long shouted words like "NOOOOOO".
+static CAPS_REGEX: Lazy<Option<Regex>> = Lazy::new(|| Regex::new(r"\b[A-Z]{5,}\b").ok());
+// ENV_VAR_REGEX: Match common environment variable patterns (UPPER_CASE_WITH_UNDERSCORES)
+// Examples: CLAUDE_SESSION_ID, GITHUB_PAT, DATABASE_URL, API_KEY
+static ENV_VAR_REGEX: Lazy<Option<Regex>> =
+    Lazy::new(|| Regex::new(r"\b[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+\b").ok());
 static PUNCT_REGEX: Lazy<Option<Regex>> = Lazy::new(|| Regex::new(r"[!?]{2,}").ok());
 static NEG_CMD_REGEX: Lazy<Option<Regex>> =
     Lazy::new(|| Regex::new(r"(?i)\b(stop|quit|never mind|forget it|give up)\b").ok());
@@ -95,11 +105,54 @@ pub fn analyze_sentiment(message: &str) -> Option<SentimentResult> {
     let mut signals = Vec::new();
     let mut additional_score = 0.0;
 
-    // ALL CAPS detection (5+ consecutive uppercase letters)
-    if let Some(ref regex) = *CAPS_REGEX {
-        if regex.is_match(trimmed) {
-            signals.push("ALL CAPS detected".to_string());
-            additional_score += 2.0;
+    // ALL CAPS detection
+    // First, strip out environment variable patterns to avoid false positives
+    // Env vars like CLAUDE_SESSION_ID, GITHUB_PAT, DATABASE_URL should not trigger
+    let text_without_env_vars = if let Some(ref env_regex) = *ENV_VAR_REGEX {
+        env_regex.replace_all(trimmed, "").to_string()
+    } else {
+        trimmed.to_string()
+    };
+
+    // Check for multiple consecutive ALL CAPS words (stronger signal than single word)
+    // "THIS REALLY SUCKS" (3 caps words) is more frustrated than "WOOSH" (1 word)
+    // Find longest run of consecutive caps words
+    let mut max_consecutive_caps = 0;
+    let mut current_run = 0;
+    for word in text_without_env_vars.split_whitespace() {
+        let clean = word.trim_matches(|c: char| !c.is_alphanumeric());
+        if clean.len() >= 2
+            && clean
+                .chars()
+                .all(|c| c.is_uppercase() || !c.is_alphabetic())
+        {
+            current_run += 1;
+            max_consecutive_caps = max_consecutive_caps.max(current_run);
+        } else {
+            current_run = 0;
+        }
+    }
+
+    // Score based on consecutive caps words (stronger signal)
+    // BUT only if sentiment is not positive - "THIS IS AMAZING" is excitement, not frustration
+    let is_positive_sentiment = sentiment_score > 0.5;
+
+    if max_consecutive_caps >= 3 && !is_positive_sentiment {
+        signals.push(format!(
+            "{} consecutive ALL CAPS words",
+            max_consecutive_caps
+        ));
+        additional_score += 3.0 + (max_consecutive_caps as f64 - 3.0) * 0.5;
+    } else if max_consecutive_caps == 2 && !is_positive_sentiment {
+        signals.push("2 consecutive ALL CAPS words".to_string());
+        additional_score += 2.5;
+    } else if !is_positive_sentiment {
+        if let Some(ref regex) = *CAPS_REGEX {
+            // Fall back to single word with 5+ letters detection
+            if regex.is_match(&text_without_env_vars) {
+                signals.push("ALL CAPS word detected".to_string());
+                additional_score += 2.0;
+            }
         }
     }
 
@@ -212,6 +265,39 @@ mod tests {
     }
 
     #[test]
+    fn test_env_vars_not_detected_as_caps() {
+        // Environment variables should NOT trigger ALL CAPS detection
+        let result = analyze_sentiment("Set the CLAUDE_SESSION_ID variable").unwrap();
+        assert!(
+            !result.signals.iter().any(|s| s.contains("CAPS")),
+            "CLAUDE_SESSION_ID should not trigger ALL CAPS"
+        );
+
+        let result = analyze_sentiment("Check GITHUB_PAT and DATABASE_URL").unwrap();
+        assert!(
+            !result.signals.iter().any(|s| s.contains("CAPS")),
+            "Multiple env vars should not trigger ALL CAPS"
+        );
+
+        let result = analyze_sentiment("The API_KEY is in .env").unwrap();
+        assert!(
+            !result.signals.iter().any(|s| s.contains("CAPS")),
+            "API_KEY should not trigger ALL CAPS"
+        );
+    }
+
+    #[test]
+    fn test_real_shouting_still_detected() {
+        // Actual shouting should still be detected even with env vars present
+        // Need 5+ consecutive uppercase letters to trigger (e.g., "WRONG", "BROKEN", "WORKING")
+        let result = analyze_sentiment("THIS IS TOTALLY WRONG and check GITHUB_PAT").unwrap();
+        assert!(
+            result.signals.iter().any(|s| s.contains("CAPS")),
+            "Real shouting (TOTALLY, WRONG) should still trigger even with env vars"
+        );
+    }
+
+    #[test]
     fn test_punctuation_detection() {
         let result = analyze_sentiment("What is going on???").unwrap();
         assert!(result.signals.iter().any(|s| s.contains("punctuation")));
@@ -237,5 +323,49 @@ mod tests {
     fn test_empty_message() {
         assert!(analyze_sentiment("").is_none());
         assert!(analyze_sentiment("   ").is_none());
+    }
+
+    #[test]
+    fn test_multiple_caps_words_higher_signal() {
+        // Multiple consecutive caps words should have higher frustration than single word
+        let single = analyze_sentiment("That's WRONG").unwrap();
+        let multiple = analyze_sentiment("THIS IS SO WRONG").unwrap();
+
+        // Multiple caps should have higher frustration score
+        let single_score = single.frustration_score.unwrap_or(0.0);
+        let multiple_score = multiple.frustration_score.unwrap_or(0.0);
+        assert!(
+            multiple_score > single_score,
+            "Multiple caps words ({}) should score higher than single ({})",
+            multiple_score,
+            single_score
+        );
+        assert!(multiple.signals.iter().any(|s| s.contains("consecutive")));
+    }
+
+    #[test]
+    fn test_positive_shouting_not_frustration() {
+        // Positive shouting like "THIS IS AMAZING" should NOT trigger frustration
+        let result = analyze_sentiment("THIS IS AMAZING! I LOVE IT!").unwrap();
+        assert_eq!(result.sentiment_level, SentimentLevel::Positive);
+        assert!(
+            !result.signals.iter().any(|s| s.contains("CAPS")),
+            "Positive shouting should not trigger CAPS frustration signal"
+        );
+        assert!(
+            result.frustration_level.is_none(),
+            "Positive shouting should not have frustration"
+        );
+    }
+
+    #[test]
+    fn test_negative_shouting_is_frustration() {
+        // Negative shouting should still be frustration
+        let result = analyze_sentiment("THIS REALLY SUCKS").unwrap();
+        assert!(
+            result.signals.iter().any(|s| s.contains("CAPS")),
+            "Negative shouting should trigger CAPS signal"
+        );
+        assert!(result.frustration_level.is_some());
     }
 }


### PR DESCRIPTION
## Summary

Improves ALL CAPS detection accuracy in sentiment analysis:

1. **Exclude environment variables** - `CLAUDE_SESSION_ID`, `GITHUB_PAT`, `DATABASE_URL` no longer trigger frustration
2. **Multiple consecutive caps words = stronger signal** - "THIS REALLY SUCKS" (3 words) scores higher than "WOOSH" (1 word)
3. **Positive shouting is excitement, not frustration** - "THIS IS AMAZING!" doesn't trigger frustration

### Scoring

| Pattern | Example | Score |
|---------|---------|-------|
| 3+ consecutive caps words | "THIS IS SO WRONG" | 3.0+ |
| 2 consecutive caps words | "SO WRONG" | 2.5 |
| Single 5+ letter caps word | "WRONG" | 2.0 |
| Env var (ignored) | `GITHUB_PAT` | 0 |
| Positive caps (ignored) | "THIS IS AMAZING" | 0 |

## Test plan

- [x] Env vars don't trigger ALL CAPS detection
- [x] Multiple consecutive caps words have higher score than single
- [x] Positive shouting doesn't trigger frustration
- [x] Negative shouting still detected
- [x] All 13 sentiment tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)