### PR TITLE
feat: support external marketplace installation

### DIFF
--- a/packages/han/lib/commands/plugin/install.ts
+++ b/packages/han/lib/commands/plugin/install.ts
@@ -69,10 +69,14 @@ export function registerPluginInstall(pluginCommand: Command): void {
       '--scope <scope>',
       'Installation scope: "project" (.claude/settings.json, default) or "local" (.claude/settings.local.json)'
     )
+    .option(
+      '--from <repo>',
+      'Install from an external GitHub marketplace repo (e.g., thebushidocollective/ai-dlc)'
+    )
     .action(
       async (
         pluginNames: string[],
-        options: { auto?: boolean; analyze?: boolean; scope?: string },
+        options: { auto?: boolean; analyze?: boolean; scope?: string; from?: string },
         command: Command
       ) => {
         try {
@@ -98,7 +102,7 @@ export function registerPluginInstall(pluginCommand: Command): void {
           if (options.auto) {
             await install(scope, { useAiAnalysis });
           } else if (pluginNames.length > 0) {
-            await installPlugins(pluginNames, scope);
+            await installPlugins(pluginNames, scope, options.from);
           } else {
             await installInteractive(scope);
           }


### PR DESCRIPTION
Add --from flag to install plugins from external repos

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- Bullet points of specific changes -->

-

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New plugin

## Plugin Changes

<!-- If adding/modifying a plugin, complete this section -->

**Plugin category:**
- [ ] Tool - Development tools and utilities
- [ ] Framework - Framework-specific skills
- [ ] Language - Language-specific skills
- [ ] Validation - Linting and validation hooks
- [ ] Discipline - Specialized agents with domain expertise
- [ ] Integration - MCP servers for external services
- [ ] Pattern - Methodologies and workflows
- [ ] Core - Han CLI or core infrastructure
- [ ] N/A - Not a plugin change

**Validation:**
- [ ] `claude plugin validate .` passes
- [ ] Hooks tested in Claude Code session (if applicable)

## Testing

- [ ] Tests pass (`cd packages/han && bun test`)
- [ ] Linting passes
- [ ] Manual testing performed

## Checklist

- [ ] Code follows existing patterns
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No new warnings
