### PR TITLE
fix(templates): expand Bushido value descriptions to remove brevity

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,15 +16,15 @@ assignees: ''
 
 ## How It Embodies Bushido
 
-<!-- Which virtues does this feature honor? -->
+<!-- Which virtues does this feature honor? Check all that apply and briefly explain how. -->
 
-- [ ] Righteousness (義) - Does the right thing
-- [ ] Courage (勇) - Makes a bold improvement
-- [ ] Compassion (仁) - Helps users or contributors
-- [ ] Respect (礼) - Honors existing conventions
-- [ ] Honesty (誠) - Transparent about trade-offs
-- [ ] Honor (名誉) - Maintains quality standards
-- [ ] Loyalty (忠義) - Long-term maintainability
+- [ ] **Righteousness (義)** — The feature does what it claims, handles edge cases honestly, and produces meaningful errors. Behavior is correct and predictable.
+- [ ] **Courage (勇)** — This makes a meaningful improvement, even if it requires challenging existing patterns or making hard architectural decisions.
+- [ ] **Compassion (仁)** — This reduces friction for users or makes it easier for future contributors to understand, extend, or debug the code.
+- [ ] **Respect (礼)** — The proposal follows established conventions, naming patterns, and architectural decisions already present in the codebase.
+- [ ] **Honesty (誠)** — Limitations, known issues, and intentional omissions are documented. Trade-offs are transparent, not hidden.
+- [ ] **Honor (名誉)** — The solution meets the quality bar for Han — well-tested, validated, and worth shipping.
+- [ ] **Loyalty (忠義)** — The design considers long-term maintainability. It avoids clever hacks and will be easy for future contributors to reason about.
 
 ## Alternatives Considered
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,6 +41,18 @@
 - [ ] Linting passes
 - [ ] Manual testing performed
 
+## How It Embodies Bushido
+
+<!-- Which virtues does this PR honor? Check all that apply and briefly explain how. -->
+
+- [ ] **Righteousness (義)** — The code does what it claims, handles edge cases honestly, and produces meaningful errors. Behavior is correct and predictable.
+- [ ] **Courage (勇)** — This change makes a meaningful improvement, even if it required challenging existing patterns or making hard architectural decisions.
+- [ ] **Compassion (仁)** — This reduces friction for users or makes it easier for future contributors to understand, extend, or debug the code.
+- [ ] **Respect (礼)** — The implementation follows established conventions, naming patterns, and architectural decisions already present in the codebase.
+- [ ] **Honesty (誠)** — Limitations, known issues, and intentional omissions are documented. Trade-offs are transparent, not hidden.
+- [ ] **Honor (名誉)** — Tests pass, validation hooks succeed, and this change meets the quality bar for what ships in Han.
+- [ ] **Loyalty (忠義)** — The implementation is maintainable long-term. It avoids clever hacks and is easy to reason about for future contributors.
+
 ## Checklist
 
 - [ ] Code follows existing patterns


### PR DESCRIPTION
Add 'How It Embodies Bushido' section to PR template and expand one-liner TBC value descriptions in both PR and feature request templates with meaningful, actionable guidance for contributors.

Closes #72

Generated with [Claude Code](https://claude.ai/code)