### PR TITLE
Add human time estimation to dashboard analytics

### DIFF
--- a/packages/browse-client/schema.graphql
+++ b/packages/browse-client/schema.graphql
@@ -369,6 +369,7 @@ type DashboardAnalytics {
 	subagentUsage: [SubagentUsageStats!]
 	toolUsage: [ToolUsageStats!]
 	performanceTrend: [SessionPerformancePoint!]
+	humanTimeEstimate: HumanTimeEstimate
 }
 
 type ExposedToolCallMessage implements Message {
@@ -887,6 +888,61 @@ type HourlyActivity {
 	hour: Int
 	sessionCount: Int
 	messageCount: Int
+}
+
+"""
+Time breakdown by activity category.
+"""
+type HumanTimeBreakdown {
+	"""
+	Category label (e.g., "Reading AI Output", "Writing Code", "Searching").
+	"""
+	category: String
+	"""
+	Estimated human seconds for this category.
+	"""
+	humanSeconds: Float
+	"""
+	Percentage of total human time.
+	"""
+	percent: Float
+}
+
+"""
+Human-equivalent time estimation for AI-completed work.
+
+Estimates how long a human developer would take to perform the same
+actions that AI completed, based on realistic human performance benchmarks:
+- Reading: 250 words per minute (~187 tokens/min)
+- Typing code: 40 words per minute (~30 tokens/min)
+- File navigation: 15–45 seconds per operation
+- Cognitive overhead: 2 minutes per decision point
+"""
+type HumanTimeEstimate {
+	"""
+	Total estimated human time in seconds.
+	"""
+	totalHumanSeconds: Float
+	"""
+	Total actual AI time in seconds (wall clock).
+	"""
+	totalAiSeconds: Float
+	"""
+	Speedup factor (human_time / ai_time).
+	"""
+	speedupFactor: Float
+	"""
+	Human hours saved (human_time - ai_time), clamped to 0.
+	"""
+	hoursSaved: Float
+	"""
+	Breakdown by activity category.
+	"""
+	breakdown: [HumanTimeBreakdown!]
+	"""
+	Per-tool-category time estimates.
+	"""
+	toolBreakdown: [ToolTimeEstimate!]
 }
 
 type ImageBlock implements ContentBlock {
@@ -2740,6 +2796,24 @@ type ToolResultUserMessage implements Message & UserMessage {
 	Number of tool results in this message.
 	"""
 	toolResultCount: Int
+}
+
+"""
+Per-tool-category human time estimate.
+"""
+type ToolTimeEstimate {
+	"""
+	Tool name or category.
+	"""
+	toolName: String
+	"""
+	Number of invocations.
+	"""
+	invocations: Int
+	"""
+	Total estimated human seconds for all invocations of this tool.
+	"""
+	humanSeconds: Float
 }
 
 """

--- a/packages/browse-client/src/components/pages/DashboardPage/DashboardContent.tsx
+++ b/packages/browse-client/src/components/pages/DashboardPage/DashboardContent.tsx
@@ -18,11 +18,15 @@ import type { GraphQLSubscriptionConfig } from "relay-runtime";
 import { theme } from "@/components/atoms";
 import { Badge } from "@/components/atoms/Badge.tsx";
 import { Box } from "@/components/atoms/Box.tsx";
+import { Center } from "@/components/atoms/Center.tsx";
 import { Heading } from "@/components/atoms/Heading.tsx";
 import { HStack } from "@/components/atoms/HStack.tsx";
 import { Text } from "@/components/atoms/Text.tsx";
 import { VStack } from "@/components/atoms/VStack.tsx";
 import { SessionListItem } from "@/components/organisms/SessionListItem.tsx";
+import { PluginItem } from "../ProjectDetailPage/PluginItem.tsx";
+import type { Plugin } from "../ProjectDetailPage/types.ts";
+import { WorktreeItem } from "../ProjectDetailPage/WorktreeItem.tsx";
 import type { DashboardContentSubscription } from "./__generated__/DashboardContentSubscription.graphql.ts";
 import type { DashboardPageActivity_query$key } from "./__generated__/DashboardPageActivity_query.graphql.ts";
 import type { DashboardPageAnalytics_query$key } from "./__generated__/DashboardPageAnalytics_query.graphql.ts";
@@ -50,10 +54,6 @@ import { PerformanceTrendChart } from "./PerformanceTrendChart.tsx";
 import { SessionEffectivenessCard } from "./SessionEffectivenessCard.tsx";
 import { SubagentUsageChart } from "./SubagentUsageChart.tsx";
 import { TimeOfDayChart } from "./TimeOfDayChart.tsx";
-
-import { PluginItem } from "../ProjectDetailPage/PluginItem.tsx";
-import type { Plugin } from "../ProjectDetailPage/types.ts";
-import { WorktreeItem } from "../ProjectDetailPage/WorktreeItem.tsx";
 import { ToolUsageChart } from "./ToolUsageChart.tsx";
 
 /**
@@ -303,25 +303,23 @@ export function DashboardContent({
 		humanTimeEstimate: {
 			totalHumanSeconds:
 				rawAnalytics?.humanTimeEstimate?.totalHumanSeconds ?? 0,
-			totalAiSeconds:
-				rawAnalytics?.humanTimeEstimate?.totalAiSeconds ?? 0,
-			speedupFactor:
-				rawAnalytics?.humanTimeEstimate?.speedupFactor ?? 0,
+			totalAiSeconds: rawAnalytics?.humanTimeEstimate?.totalAiSeconds ?? 0,
+			speedupFactor: rawAnalytics?.humanTimeEstimate?.speedupFactor ?? 0,
 			hoursSaved: rawAnalytics?.humanTimeEstimate?.hoursSaved ?? 0,
-			breakdown: (
-				rawAnalytics?.humanTimeEstimate?.breakdown ?? []
-			).map((b) => ({
-				category: b?.category ?? "",
-				humanSeconds: b?.humanSeconds ?? 0,
-				percent: b?.percent ?? 0,
-			})),
-			toolBreakdown: (
-				rawAnalytics?.humanTimeEstimate?.toolBreakdown ?? []
-			).map((t) => ({
-				toolName: t?.toolName ?? "",
-				invocations: t?.invocations ?? 0,
-				humanSeconds: t?.humanSeconds ?? 0,
-			})),
+			breakdown: (rawAnalytics?.humanTimeEstimate?.breakdown ?? []).map(
+				(b) => ({
+					category: b?.category ?? "",
+					humanSeconds: b?.humanSeconds ?? 0,
+					percent: b?.percent ?? 0,
+				}),
+			),
+			toolBreakdown: (rawAnalytics?.humanTimeEstimate?.toolBreakdown ?? []).map(
+				(t) => ({
+					toolName: t?.toolName ?? "",
+					invocations: t?.invocations ?? 0,
+					humanSeconds: t?.humanSeconds ?? 0,
+				}),
+			),
 		},
 		costAnalysis: {
 			estimatedCostUsd: rawAnalytics?.costAnalysis?.estimatedCostUsd ?? 0,
@@ -706,20 +704,11 @@ export function DashboardContent({
 			{/* Human Time Estimation - full width */}
 			<SectionCard title="Human Time Estimation (30 days)">
 				{analyticsLoaded ? (
-					<HumanTimeCard
-						humanTimeEstimate={analytics.humanTimeEstimate}
-					/>
+					<HumanTimeCard humanTimeEstimate={analytics.humanTimeEstimate} />
 				) : (
-					<Box
-						style={{
-							display: "flex",
-							alignItems: "center",
-							justifyContent: "center",
-							minHeight: "120px",
-						}}
-					>
+					<Center style={{ minHeight: 120 }}>
 						<Text color="muted">Loading time estimation...</Text>
-					</Box>
+					</Center>
 				)}
 			</SectionCard>
 

--- a/packages/browse-client/src/components/pages/DashboardPage/DashboardContent.tsx
+++ b/packages/browse-client/src/components/pages/DashboardPage/DashboardContent.tsx
@@ -38,6 +38,7 @@ import {
 	StatusItem,
 } from "./components.ts";
 import { HookHealthCard } from "./HookHealthCard.tsx";
+import { HumanTimeCard } from "./HumanTimeCard.tsx";
 import {
 	DashboardActivityFragment,
 	DashboardAnalyticsFragment,
@@ -299,6 +300,29 @@ export function DashboardContent({
 			avgCompactions: p?.avgCompactions ?? 0,
 			avgEffectiveness: p?.avgEffectiveness ?? 0,
 		})),
+		humanTimeEstimate: {
+			totalHumanSeconds:
+				rawAnalytics?.humanTimeEstimate?.totalHumanSeconds ?? 0,
+			totalAiSeconds:
+				rawAnalytics?.humanTimeEstimate?.totalAiSeconds ?? 0,
+			speedupFactor:
+				rawAnalytics?.humanTimeEstimate?.speedupFactor ?? 0,
+			hoursSaved: rawAnalytics?.humanTimeEstimate?.hoursSaved ?? 0,
+			breakdown: (
+				rawAnalytics?.humanTimeEstimate?.breakdown ?? []
+			).map((b) => ({
+				category: b?.category ?? "",
+				humanSeconds: b?.humanSeconds ?? 0,
+				percent: b?.percent ?? 0,
+			})),
+			toolBreakdown: (
+				rawAnalytics?.humanTimeEstimate?.toolBreakdown ?? []
+			).map((t) => ({
+				toolName: t?.toolName ?? "",
+				invocations: t?.invocations ?? 0,
+				humanSeconds: t?.humanSeconds ?? 0,
+			})),
+		},
 		costAnalysis: {
 			estimatedCostUsd: rawAnalytics?.costAnalysis?.estimatedCostUsd ?? 0,
 			isEstimated: rawAnalytics?.costAnalysis?.isEstimated ?? true,
@@ -678,6 +702,26 @@ export function DashboardContent({
 					</SectionCard>
 				</Box>
 			</HStack>
+
+			{/* Human Time Estimation - full width */}
+			<SectionCard title="Human Time Estimation (30 days)">
+				{analyticsLoaded ? (
+					<HumanTimeCard
+						humanTimeEstimate={analytics.humanTimeEstimate}
+					/>
+				) : (
+					<Box
+						style={{
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							minHeight: "120px",
+						}}
+					>
+						<Text color="muted">Loading time estimation...</Text>
+					</Box>
+				)}
+			</SectionCard>
 
 			{/* Performance Trend - full width */}
 			<SectionCard title="Session Performance Trend (30 days)">

--- a/packages/browse-client/src/components/pages/DashboardPage/HumanTimeCard.tsx
+++ b/packages/browse-client/src/components/pages/DashboardPage/HumanTimeCard.tsx
@@ -48,10 +48,10 @@ interface HumanTimeCardProps {
 // =============================================================================
 
 const CATEGORY_COLORS: Record<string, string> = {
-	"Reading AI Output": "#3b82f6",
-	"Writing Code": "#10b981",
-	"Thinking & Deciding": "#f59e0b",
-	"Navigation & Tools": "#8b5cf6",
+	"Reading AI Output": theme.colors.primary,
+	"Writing Code": theme.colors.success,
+	"Thinking & Deciding": theme.colors.warning,
+	"Navigation & Tools": theme.colors.purple,
 };
 
 function getSpeedupDisplay(factor: number): {
@@ -62,28 +62,28 @@ function getSpeedupDisplay(factor: number): {
 	if (factor >= 100) {
 		return {
 			label: `${Math.round(factor)}x faster`,
-			color: "#10b981",
-			bgColor: "rgba(16, 185, 129, 0.15)",
+			color: theme.colors.success,
+			bgColor: `${theme.colors.success}26`,
 		};
 	}
 	if (factor >= 10) {
 		return {
 			label: `${Math.round(factor)}x faster`,
-			color: "#3b82f6",
-			bgColor: "rgba(59, 130, 246, 0.15)",
+			color: theme.colors.primary,
+			bgColor: `${theme.colors.primary}26`,
 		};
 	}
 	if (factor >= 2) {
 		return {
 			label: `${factor.toFixed(1)}x faster`,
-			color: "#8b5cf6",
-			bgColor: "rgba(139, 92, 246, 0.15)",
+			color: theme.colors.purple,
+			bgColor: `${theme.colors.purple}26`,
 		};
 	}
 	return {
 		label: `${factor.toFixed(1)}x faster`,
-		color: "#f59e0b",
-		bgColor: "rgba(245, 158, 11, 0.15)",
+		color: theme.colors.warning,
+		bgColor: `${theme.colors.warning}26`,
 	};
 }
 
@@ -101,10 +101,7 @@ export function HumanTimeCard({
 
 	const maxBreakdownSecs = useMemo(
 		() =>
-			Math.max(
-				...humanTimeEstimate.breakdown.map((b) => b.humanSeconds),
-				1,
-			),
+			Math.max(...humanTimeEstimate.breakdown.map((b) => b.humanSeconds), 1),
 		[humanTimeEstimate.breakdown],
 	);
 
@@ -179,7 +176,7 @@ export function HumanTimeCard({
 						style={{
 							width: `${Math.max((humanTimeEstimate.totalAiSeconds / humanTimeEstimate.totalHumanSeconds) * 100, 2)}%`,
 							height: "100%",
-							backgroundColor: "#10b981",
+							backgroundColor: theme.colors.success,
 						}}
 					/>
 					{/* Human portion - the rest */}
@@ -187,15 +184,15 @@ export function HumanTimeCard({
 						style={{
 							flex: 1,
 							height: "100%",
-							backgroundColor: "#f59e0b",
+							backgroundColor: theme.colors.warning,
 						}}
 					/>
 				</Box>
 				<HStack justify="space-between" align="center">
-					<Text size="xs" style={{ color: "#10b981" }}>
+					<Text size="xs" style={{ color: theme.colors.success }}>
 						{formatDuration(Math.round(humanTimeEstimate.totalAiSeconds))}
 					</Text>
-					<Text size="xs" style={{ color: "#f59e0b" }}>
+					<Text size="xs" style={{ color: theme.colors.warning }}>
 						{formatDuration(Math.round(humanTimeEstimate.totalHumanSeconds))}
 					</Text>
 				</HStack>
@@ -216,7 +213,10 @@ export function HumanTimeCard({
 						Speedup Factor
 					</Text>
 					<Text weight="semibold" size="lg">
-						{humanTimeEstimate.speedupFactor}x
+						{humanTimeEstimate.speedupFactor >= 10
+							? Math.round(humanTimeEstimate.speedupFactor)
+							: humanTimeEstimate.speedupFactor.toFixed(1)}
+						x
 					</Text>
 				</VStack>
 			</HStack>
@@ -233,11 +233,7 @@ export function HumanTimeCard({
 						align="center"
 						style={{ width: "100%" }}
 					>
-						<Text
-							size="xs"
-							color="muted"
-							style={{ width: 130, flexShrink: 0 }}
-						>
+						<Text size="xs" color="muted" style={{ width: 130, flexShrink: 0 }}>
 							{entry.category}
 						</Text>
 						<Box
@@ -254,7 +250,7 @@ export function HumanTimeCard({
 									width: `${Math.max((entry.humanSeconds / maxBreakdownSecs) * 100, entry.humanSeconds > 0 ? 2 : 0)}%`,
 									height: "100%",
 									backgroundColor:
-										CATEGORY_COLORS[entry.category] ?? "#6b7280",
+										CATEGORY_COLORS[entry.category] ?? theme.colors.text.muted,
 									borderRadius: theme.radii.sm,
 								}}
 							/>
@@ -286,7 +282,7 @@ export function HumanTimeCard({
 							<Text
 								size="xs"
 								color="muted"
-								style={{ width: 60, flexShrink: 0 }}
+								style={{ width: 95, flexShrink: 0 }}
 							>
 								{tool.toolName}
 							</Text>
@@ -303,7 +299,7 @@ export function HumanTimeCard({
 									style={{
 										width: `${Math.max((tool.humanSeconds / maxToolSecs) * 100, tool.humanSeconds > 0 ? 2 : 0)}%`,
 										height: "100%",
-										backgroundColor: "#6366f1",
+										backgroundColor: theme.colors.primary,
 										borderRadius: theme.radii.sm,
 									}}
 								/>
@@ -313,7 +309,8 @@ export function HumanTimeCard({
 								color="muted"
 								style={{ width: 80, textAlign: "right" }}
 							>
-								{tool.invocations}x = {formatDuration(Math.round(tool.humanSeconds))}
+								{tool.invocations}x ={" "}
+								{formatDuration(Math.round(tool.humanSeconds))}
 							</Text>
 						</HStack>
 					))}
@@ -324,14 +321,16 @@ export function HumanTimeCard({
 			<Box
 				style={{
 					padding: theme.spacing.sm,
-					backgroundColor: "rgba(16, 185, 129, 0.1)",
-					borderRadius: theme.borderRadius.md,
+					backgroundColor: `${theme.colors.success}1A`,
+					borderRadius: theme.radii.md,
 					borderLeftWidth: 3,
-					borderLeftColor: "#10b981",
+					borderLeftColor: theme.colors.success,
 				}}
 			>
 				<Text size="xs" color="muted">
-					Estimates based on human benchmarks: 250 WPM reading, 40 WPM typing, 30-60s per tool operation, 2min per decision point
+					Estimates based on human benchmarks: 250 WPM reading, 40 WPM typing,
+					30-60s per tool operation, 5-120s per decision (scaled by prompt
+					length)
 				</Text>
 			</Box>
 		</VStack>

--- a/packages/browse-client/src/components/pages/DashboardPage/HumanTimeCard.tsx
+++ b/packages/browse-client/src/components/pages/DashboardPage/HumanTimeCard.tsx
@@ -1,0 +1,339 @@
+/**
+ * Human Time Estimation Card Component
+ *
+ * Shows how long a human would take to perform the same work that AI completed,
+ * with a speedup factor and breakdown by activity category.
+ */
+
+import type React from "react";
+import { useMemo } from "react";
+import { theme } from "@/components/atoms";
+import { Box } from "@/components/atoms/Box.tsx";
+import { HStack } from "@/components/atoms/HStack.tsx";
+import { Text } from "@/components/atoms/Text.tsx";
+import { VStack } from "@/components/atoms/VStack.tsx";
+import { formatDuration } from "@/components/helpers/formatters.ts";
+
+// =============================================================================
+// Interfaces
+// =============================================================================
+
+interface HumanTimeBreakdown {
+	readonly category: string;
+	readonly humanSeconds: number;
+	readonly percent: number;
+}
+
+interface ToolTimeEstimate {
+	readonly toolName: string;
+	readonly invocations: number;
+	readonly humanSeconds: number;
+}
+
+interface HumanTimeEstimate {
+	readonly totalHumanSeconds: number;
+	readonly totalAiSeconds: number;
+	readonly speedupFactor: number;
+	readonly hoursSaved: number;
+	readonly breakdown: readonly HumanTimeBreakdown[];
+	readonly toolBreakdown: readonly ToolTimeEstimate[];
+}
+
+interface HumanTimeCardProps {
+	humanTimeEstimate: HumanTimeEstimate;
+}
+
+// =============================================================================
+// Color mapping for categories
+// =============================================================================
+
+const CATEGORY_COLORS: Record<string, string> = {
+	"Reading AI Output": "#3b82f6",
+	"Writing Code": "#10b981",
+	"Thinking & Deciding": "#f59e0b",
+	"Navigation & Tools": "#8b5cf6",
+};
+
+function getSpeedupDisplay(factor: number): {
+	label: string;
+	color: string;
+	bgColor: string;
+} {
+	if (factor >= 100) {
+		return {
+			label: `${Math.round(factor)}x faster`,
+			color: "#10b981",
+			bgColor: "rgba(16, 185, 129, 0.15)",
+		};
+	}
+	if (factor >= 10) {
+		return {
+			label: `${Math.round(factor)}x faster`,
+			color: "#3b82f6",
+			bgColor: "rgba(59, 130, 246, 0.15)",
+		};
+	}
+	if (factor >= 2) {
+		return {
+			label: `${factor.toFixed(1)}x faster`,
+			color: "#8b5cf6",
+			bgColor: "rgba(139, 92, 246, 0.15)",
+		};
+	}
+	return {
+		label: `${factor.toFixed(1)}x faster`,
+		color: "#f59e0b",
+		bgColor: "rgba(245, 158, 11, 0.15)",
+	};
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function HumanTimeCard({
+	humanTimeEstimate,
+}: HumanTimeCardProps): React.ReactElement {
+	const speedup = useMemo(
+		() => getSpeedupDisplay(humanTimeEstimate.speedupFactor),
+		[humanTimeEstimate.speedupFactor],
+	);
+
+	const maxBreakdownSecs = useMemo(
+		() =>
+			Math.max(
+				...humanTimeEstimate.breakdown.map((b) => b.humanSeconds),
+				1,
+			),
+		[humanTimeEstimate.breakdown],
+	);
+
+	const maxToolSecs = useMemo(
+		() =>
+			Math.max(
+				...humanTimeEstimate.toolBreakdown.map((t) => t.humanSeconds),
+				1,
+			),
+		[humanTimeEstimate.toolBreakdown],
+	);
+
+	if (humanTimeEstimate.totalHumanSeconds === 0) {
+		return (
+			<VStack gap="md" style={{ width: "100%" }}>
+				<Text color="muted" size="sm">
+					No data available for human time estimation.
+				</Text>
+			</VStack>
+		);
+	}
+
+	return (
+		<VStack gap="md" style={{ width: "100%" }}>
+			{/* Header: speedup badge + time saved */}
+			<HStack justify="space-between" align="center">
+				<VStack gap="xs">
+					<Text color="secondary" size="xs">
+						Estimated Human Equivalent
+					</Text>
+					<Text weight="semibold" size="lg">
+						{formatDuration(Math.round(humanTimeEstimate.totalHumanSeconds))}
+					</Text>
+				</VStack>
+				<Box
+					style={{
+						paddingHorizontal: theme.spacing.md,
+						paddingVertical: theme.spacing.xs,
+						backgroundColor: speedup.bgColor,
+						borderRadius: theme.radii.full,
+					}}
+				>
+					<Text weight="semibold" size="sm" style={{ color: speedup.color }}>
+						{speedup.label}
+					</Text>
+				</Box>
+			</HStack>
+
+			{/* AI time vs Human time comparison bar */}
+			<VStack gap="xs" style={{ width: "100%" }}>
+				<HStack justify="space-between" align="center">
+					<Text color="muted" size="xs">
+						AI (actual)
+					</Text>
+					<Text color="muted" size="xs">
+						Human (estimated)
+					</Text>
+				</HStack>
+				<Box
+					style={{
+						display: "flex",
+						flexDirection: "row",
+						height: 12,
+						borderRadius: theme.radii.md,
+						overflow: "hidden",
+						backgroundColor: theme.colors.bg.tertiary,
+						width: "100%",
+					}}
+				>
+					{/* AI portion - tiny sliver relative to human time */}
+					<Box
+						style={{
+							width: `${Math.max((humanTimeEstimate.totalAiSeconds / humanTimeEstimate.totalHumanSeconds) * 100, 2)}%`,
+							height: "100%",
+							backgroundColor: "#10b981",
+						}}
+					/>
+					{/* Human portion - the rest */}
+					<Box
+						style={{
+							flex: 1,
+							height: "100%",
+							backgroundColor: "#f59e0b",
+						}}
+					/>
+				</Box>
+				<HStack justify="space-between" align="center">
+					<Text size="xs" style={{ color: "#10b981" }}>
+						{formatDuration(Math.round(humanTimeEstimate.totalAiSeconds))}
+					</Text>
+					<Text size="xs" style={{ color: "#f59e0b" }}>
+						{formatDuration(Math.round(humanTimeEstimate.totalHumanSeconds))}
+					</Text>
+				</HStack>
+			</VStack>
+
+			{/* Key stats */}
+			<HStack gap="lg">
+				<VStack gap="xs">
+					<Text color="secondary" size="xs">
+						Hours Saved
+					</Text>
+					<Text weight="semibold" size="lg">
+						{humanTimeEstimate.hoursSaved.toFixed(1)}h
+					</Text>
+				</VStack>
+				<VStack gap="xs">
+					<Text color="secondary" size="xs">
+						Speedup Factor
+					</Text>
+					<Text weight="semibold" size="lg">
+						{humanTimeEstimate.speedupFactor}x
+					</Text>
+				</VStack>
+			</HStack>
+
+			{/* Activity category breakdown bars */}
+			<VStack gap="sm" style={{ width: "100%" }}>
+				<Text color="secondary" size="xs">
+					Time Breakdown (Human Equivalent)
+				</Text>
+				{humanTimeEstimate.breakdown.map((entry) => (
+					<HStack
+						key={entry.category}
+						gap="sm"
+						align="center"
+						style={{ width: "100%" }}
+					>
+						<Text
+							size="xs"
+							color="muted"
+							style={{ width: 130, flexShrink: 0 }}
+						>
+							{entry.category}
+						</Text>
+						<Box
+							style={{
+								flex: 1,
+								height: 8,
+								backgroundColor: theme.colors.bg.tertiary,
+								borderRadius: theme.radii.sm,
+								overflow: "hidden",
+							}}
+						>
+							<Box
+								style={{
+									width: `${Math.max((entry.humanSeconds / maxBreakdownSecs) * 100, entry.humanSeconds > 0 ? 2 : 0)}%`,
+									height: "100%",
+									backgroundColor:
+										CATEGORY_COLORS[entry.category] ?? "#6b7280",
+									borderRadius: theme.radii.sm,
+								}}
+							/>
+						</Box>
+						<Text
+							size="xs"
+							weight="semibold"
+							style={{ width: 50, textAlign: "right" }}
+						>
+							{formatDuration(Math.round(entry.humanSeconds))}
+						</Text>
+					</HStack>
+				))}
+			</VStack>
+
+			{/* Per-tool breakdown */}
+			{humanTimeEstimate.toolBreakdown.length > 0 && (
+				<VStack gap="sm" style={{ width: "100%" }}>
+					<Text color="secondary" size="xs">
+						Tool Navigation Overhead
+					</Text>
+					{humanTimeEstimate.toolBreakdown.map((tool) => (
+						<HStack
+							key={tool.toolName}
+							gap="sm"
+							align="center"
+							style={{ width: "100%" }}
+						>
+							<Text
+								size="xs"
+								color="muted"
+								style={{ width: 60, flexShrink: 0 }}
+							>
+								{tool.toolName}
+							</Text>
+							<Box
+								style={{
+									flex: 1,
+									height: 6,
+									backgroundColor: theme.colors.bg.tertiary,
+									borderRadius: theme.radii.sm,
+									overflow: "hidden",
+								}}
+							>
+								<Box
+									style={{
+										width: `${Math.max((tool.humanSeconds / maxToolSecs) * 100, tool.humanSeconds > 0 ? 2 : 0)}%`,
+										height: "100%",
+										backgroundColor: "#6366f1",
+										borderRadius: theme.radii.sm,
+									}}
+								/>
+							</Box>
+							<Text
+								size="xs"
+								color="muted"
+								style={{ width: 80, textAlign: "right" }}
+							>
+								{tool.invocations}x = {formatDuration(Math.round(tool.humanSeconds))}
+							</Text>
+						</HStack>
+					))}
+				</VStack>
+			)}
+
+			{/* Callout */}
+			<Box
+				style={{
+					padding: theme.spacing.sm,
+					backgroundColor: "rgba(16, 185, 129, 0.1)",
+					borderRadius: theme.borderRadius.md,
+					borderLeftWidth: 3,
+					borderLeftColor: "#10b981",
+				}}
+			>
+				<Text size="xs" color="muted">
+					Estimates based on human benchmarks: 250 WPM reading, 40 WPM typing, 30-60s per tool operation, 2min per decision point
+				</Text>
+			</Box>
+		</VStack>
+	);
+}

--- a/packages/browse-client/src/components/pages/DashboardPage/HumanTimeCard.tsx
+++ b/packages/browse-client/src/components/pages/DashboardPage/HumanTimeCard.tsx
@@ -160,10 +160,8 @@ export function HumanTimeCard({
 						Human (estimated)
 					</Text>
 				</HStack>
-				<Box
+				<HStack
 					style={{
-						display: "flex",
-						flexDirection: "row",
 						height: 12,
 						borderRadius: theme.radii.md,
 						overflow: "hidden",
@@ -187,7 +185,7 @@ export function HumanTimeCard({
 							backgroundColor: theme.colors.warning,
 						}}
 					/>
-				</Box>
+				</HStack>
 				<HStack justify="space-between" align="center">
 					<Text size="xs" style={{ color: theme.colors.success }}>
 						{formatDuration(Math.round(humanTimeEstimate.totalAiSeconds))}

--- a/packages/browse-client/src/components/pages/DashboardPage/__generated__/DashboardPageAnalytics_query.graphql.ts
+++ b/packages/browse-client/src/components/pages/DashboardPage/__generated__/DashboardPageAnalytics_query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<35fc5dcdba303dc5dec795b41e2535b0>>
+ * @generated SignedSource<<fa7aec1a77d2a8bc4a33325283f84adf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -130,6 +130,22 @@ export type DashboardPageAnalytics_query$data = {
       readonly passRate: number | null | undefined;
       readonly totalRuns: number | null | undefined;
     }> | null | undefined;
+    readonly humanTimeEstimate: {
+      readonly breakdown: ReadonlyArray<{
+        readonly category: string | null | undefined;
+        readonly humanSeconds: number | null | undefined;
+        readonly percent: number | null | undefined;
+      }> | null | undefined;
+      readonly hoursSaved: number | null | undefined;
+      readonly speedupFactor: number | null | undefined;
+      readonly toolBreakdown: ReadonlyArray<{
+        readonly humanSeconds: number | null | undefined;
+        readonly invocations: number | null | undefined;
+        readonly toolName: string | null | undefined;
+      }> | null | undefined;
+      readonly totalAiSeconds: number | null | undefined;
+      readonly totalHumanSeconds: number | null | undefined;
+    } | null | undefined;
     readonly performanceTrend: ReadonlyArray<{
       readonly avgCompactions: number | null | undefined;
       readonly avgEffectiveness: number | null | undefined;
@@ -261,59 +277,73 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "weekStart",
+  "name": "toolName",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "weekLabel",
+  "name": "weekStart",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "sessionCount",
+  "name": "weekLabel",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "estimatedCostUsd",
+  "name": "sessionCount",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isEstimated",
+  "name": "humanSeconds",
   "storageKey": null
 },
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cacheSavingsUsd",
+  "name": "estimatedCostUsd",
   "storageKey": null
 },
 v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "costUtilizationPercent",
+  "name": "isEstimated",
   "storageKey": null
 },
 v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "costUsd",
+  "name": "cacheSavingsUsd",
   "storageKey": null
 },
 v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "costUtilizationPercent",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "costUsd",
+  "storageKey": null
+},
+v15 = {
   "alias": null,
   "args": null,
   "concreteType": "DailyCost",
@@ -328,12 +358,12 @@ v13 = {
       "name": "date",
       "storageKey": null
     },
-    (v12/*: any*/),
-    (v7/*: any*/)
+    (v14/*: any*/),
+    (v8/*: any*/)
   ],
   "storageKey": null
 },
-v14 = {
+v16 = {
   "alias": null,
   "args": null,
   "concreteType": "WeeklyCost",
@@ -341,10 +371,10 @@ v14 = {
   "name": "weeklyCostTrend",
   "plural": true,
   "selections": [
-    (v5/*: any*/),
     (v6/*: any*/),
-    (v12/*: any*/),
     (v7/*: any*/),
+    (v14/*: any*/),
+    (v8/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -355,7 +385,7 @@ v14 = {
   ],
   "storageKey": null
 },
-v15 = {
+v17 = {
   "alias": null,
   "args": null,
   "concreteType": "SessionCost",
@@ -365,7 +395,7 @@ v15 = {
   "selections": [
     (v1/*: any*/),
     (v2/*: any*/),
-    (v12/*: any*/),
+    (v14/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -398,28 +428,28 @@ v15 = {
   ],
   "storageKey": null
 },
-v16 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "costPerSession",
   "storageKey": null
 },
-v17 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cacheHitRate",
   "storageKey": null
 },
-v18 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "potentialSavingsUsd",
   "storageKey": null
 },
-v19 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "SubscriptionComparison",
@@ -472,7 +502,7 @@ v19 = {
   ],
   "storageKey": null
 },
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -627,13 +657,7 @@ return {
           "name": "toolUsage",
           "plural": true,
           "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "toolName",
-              "storageKey": null
-            },
+            (v5/*: any*/),
             (v0/*: any*/)
           ],
           "storageKey": null
@@ -699,9 +723,9 @@ return {
           "name": "performanceTrend",
           "plural": true,
           "selections": [
-            (v5/*: any*/),
             (v6/*: any*/),
             (v7/*: any*/),
+            (v8/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -729,13 +753,98 @@ return {
         {
           "alias": null,
           "args": null,
+          "concreteType": "HumanTimeEstimate",
+          "kind": "LinkedField",
+          "name": "humanTimeEstimate",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totalHumanSeconds",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totalAiSeconds",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "speedupFactor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hoursSaved",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "HumanTimeBreakdown",
+              "kind": "LinkedField",
+              "name": "breakdown",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "category",
+                  "storageKey": null
+                },
+                (v9/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "percent",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "ToolTimeEstimate",
+              "kind": "LinkedField",
+              "name": "toolBreakdown",
+              "plural": true,
+              "selections": [
+                (v5/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "invocations",
+                  "storageKey": null
+                },
+                (v9/*: any*/)
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
           "concreteType": "CostAnalysis",
           "kind": "LinkedField",
           "name": "costAnalysis",
           "plural": false,
           "selections": [
-            (v8/*: any*/),
-            (v9/*: any*/),
+            (v10/*: any*/),
+            (v11/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -743,7 +852,7 @@ return {
               "name": "billingType",
               "storageKey": null
             },
-            (v10/*: any*/),
+            (v12/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -751,11 +860,11 @@ return {
               "name": "maxSubscriptionCostUsd",
               "storageKey": null
             },
-            (v11/*: any*/),
             (v13/*: any*/),
-            (v14/*: any*/),
             (v15/*: any*/),
             (v16/*: any*/),
+            (v17/*: any*/),
+            (v18/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -763,10 +872,10 @@ return {
               "name": "costPerCompletedTask",
               "storageKey": null
             },
-            (v17/*: any*/),
-            (v18/*: any*/),
             (v19/*: any*/),
             (v20/*: any*/),
+            (v21/*: any*/),
+            (v22/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -789,9 +898,9 @@ return {
                   "name": "configDirName",
                   "storageKey": null
                 },
-                (v8/*: any*/),
-                (v9/*: any*/),
                 (v10/*: any*/),
+                (v11/*: any*/),
+                (v12/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -813,15 +922,15 @@ return {
                   "name": "modelCount",
                   "storageKey": null
                 },
-                (v16/*: any*/),
-                (v17/*: any*/),
                 (v18/*: any*/),
-                (v11/*: any*/),
-                (v13/*: any*/),
-                (v14/*: any*/),
                 (v19/*: any*/),
                 (v20/*: any*/),
-                (v15/*: any*/)
+                (v13/*: any*/),
+                (v15/*: any*/),
+                (v16/*: any*/),
+                (v21/*: any*/),
+                (v22/*: any*/),
+                (v17/*: any*/)
               ],
               "storageKey": null
             }
@@ -837,6 +946,6 @@ return {
 };
 })();
 
-(node as any).hash = "96a8d421cd83944dc0055258813ebf6f";
+(node as any).hash = "2399141ecd4a8f97f8c92cb8bb2f639d";
 
 export default node;

--- a/packages/browse-client/src/components/pages/DashboardPage/__generated__/DashboardPageQuery.graphql.ts
+++ b/packages/browse-client/src/components/pages/DashboardPage/__generated__/DashboardPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1075d07b846a06739f1e2ac92a588dae>>
+ * @generated SignedSource<<7c1265b57580d3673f4b980569a11edf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -684,38 +684,52 @@ v51 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "weekStart",
+  "name": "toolName",
   "storageKey": null
 },
 v52 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "weekLabel",
+  "name": "weekStart",
   "storageKey": null
 },
 v53 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "isEstimated",
+  "name": "weekLabel",
   "storageKey": null
 },
 v54 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cacheSavingsUsd",
+  "name": "humanSeconds",
   "storageKey": null
 },
 v55 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "costUtilizationPercent",
+  "name": "isEstimated",
   "storageKey": null
 },
 v56 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cacheSavingsUsd",
+  "storageKey": null
+},
+v57 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "costUtilizationPercent",
+  "storageKey": null
+},
+v58 = {
   "alias": null,
   "args": null,
   "concreteType": "DailyCost",
@@ -729,7 +743,7 @@ v56 = {
   ],
   "storageKey": null
 },
-v57 = {
+v59 = {
   "alias": null,
   "args": null,
   "concreteType": "WeeklyCost",
@@ -737,8 +751,8 @@ v57 = {
   "name": "weeklyCostTrend",
   "plural": true,
   "selections": [
-    (v51/*: any*/),
     (v52/*: any*/),
+    (v53/*: any*/),
     (v47/*: any*/),
     (v13/*: any*/),
     {
@@ -751,7 +765,7 @@ v57 = {
   ],
   "storageKey": null
 },
-v58 = {
+v60 = {
   "alias": null,
   "args": null,
   "concreteType": "SessionCost",
@@ -770,28 +784,28 @@ v58 = {
   ],
   "storageKey": null
 },
-v59 = {
+v61 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "costPerSession",
   "storageKey": null
 },
-v60 = {
+v62 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cacheHitRate",
   "storageKey": null
 },
-v61 = {
+v63 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "potentialSavingsUsd",
   "storageKey": null
 },
-v62 = {
+v64 = {
   "alias": null,
   "args": null,
   "concreteType": "SubscriptionComparison",
@@ -844,7 +858,7 @@ v62 = {
   ],
   "storageKey": null
 },
-v63 = {
+v65 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -1690,13 +1704,7 @@ return {
             "name": "toolUsage",
             "plural": true,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "toolName",
-                "storageKey": null
-              },
+              (v51/*: any*/),
               (v28/*: any*/)
             ],
             "storageKey": null
@@ -1762,8 +1770,8 @@ return {
             "name": "performanceTrend",
             "plural": true,
             "selections": [
-              (v51/*: any*/),
               (v52/*: any*/),
+              (v53/*: any*/),
               (v13/*: any*/),
               {
                 "alias": null,
@@ -1792,13 +1800,92 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "HumanTimeEstimate",
+            "kind": "LinkedField",
+            "name": "humanTimeEstimate",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalHumanSeconds",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalAiSeconds",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "speedupFactor",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "hoursSaved",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "HumanTimeBreakdown",
+                "kind": "LinkedField",
+                "name": "breakdown",
+                "plural": true,
+                "selections": [
+                  (v16/*: any*/),
+                  (v54/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "percent",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ToolTimeEstimate",
+                "kind": "LinkedField",
+                "name": "toolBreakdown",
+                "plural": true,
+                "selections": [
+                  (v51/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "invocations",
+                    "storageKey": null
+                  },
+                  (v54/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "CostAnalysis",
             "kind": "LinkedField",
             "name": "costAnalysis",
             "plural": false,
             "selections": [
               (v39/*: any*/),
-              (v53/*: any*/),
+              (v55/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1806,7 +1893,7 @@ return {
                 "name": "billingType",
                 "storageKey": null
               },
-              (v54/*: any*/),
+              (v56/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1814,11 +1901,11 @@ return {
                 "name": "maxSubscriptionCostUsd",
                 "storageKey": null
               },
-              (v55/*: any*/),
-              (v56/*: any*/),
               (v57/*: any*/),
               (v58/*: any*/),
               (v59/*: any*/),
+              (v60/*: any*/),
+              (v61/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1826,10 +1913,10 @@ return {
                 "name": "costPerCompletedTask",
                 "storageKey": null
               },
-              (v60/*: any*/),
-              (v61/*: any*/),
               (v62/*: any*/),
               (v63/*: any*/),
+              (v64/*: any*/),
+              (v65/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1853,8 +1940,8 @@ return {
                     "storageKey": null
                   },
                   (v39/*: any*/),
-                  (v53/*: any*/),
-                  (v54/*: any*/),
+                  (v55/*: any*/),
+                  (v56/*: any*/),
                   (v10/*: any*/),
                   (v48/*: any*/),
                   {
@@ -1864,15 +1951,15 @@ return {
                     "name": "modelCount",
                     "storageKey": null
                   },
-                  (v59/*: any*/),
-                  (v60/*: any*/),
                   (v61/*: any*/),
-                  (v55/*: any*/),
-                  (v56/*: any*/),
-                  (v57/*: any*/),
                   (v62/*: any*/),
                   (v63/*: any*/),
-                  (v58/*: any*/)
+                  (v57/*: any*/),
+                  (v58/*: any*/),
+                  (v59/*: any*/),
+                  (v64/*: any*/),
+                  (v65/*: any*/),
+                  (v60/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1885,7 +1972,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "570fc75a5559d4d9461e1d576ec6e4d2",
+    "cacheID": "a7ca64bbb363d75ea5f2b0897dd09d41",
     "id": null,
     "metadata": {
       "connection": [
@@ -1901,7 +1988,7 @@ return {
     },
     "name": "DashboardPageQuery",
     "operationKind": "query",
-    "text": "query DashboardPageQuery(\n  $repoId: String!\n  $hasRepoId: Boolean!\n  $projectId: String!\n  $hasProjectId: Boolean!\n  $sessionFilter: SessionFilter\n) {\n  repo(id: $repoId) @include(if: $hasRepoId) {\n    name\n    id\n  }\n  project(id: $projectId) @include(if: $hasProjectId) {\n    id\n    projectId\n    name\n    totalSessions\n    lastActivity\n    worktrees {\n      name\n      path\n      sessionCount\n      isWorktree\n      subdirs {\n        relativePath\n        path\n        sessionCount\n        id\n      }\n      id\n    }\n    plugins {\n      id\n      name\n      marketplace\n      scope\n      enabled\n      category\n    }\n  }\n  projects(first: 100) {\n    id\n  }\n  sessions(first: 5, filter: $sessionFilter) {\n    edges {\n      node {\n        id\n        ...SessionListItem_session\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  metrics(period: WEEK, projectId: $projectId, repoId: $repoId) {\n    totalTasks\n    completedTasks\n    successRate\n    averageConfidence\n    calibrationScore\n    significantFrustrations\n    significantFrustrationRate\n  }\n  pluginStats {\n    totalPlugins\n    userPlugins\n    projectPlugins\n    localPlugins\n    enabledPlugins\n  }\n  pluginCategories {\n    category\n    count\n  }\n  ...DashboardPageActivity_query_2Q0WS9\n  ...DashboardPageAnalytics_query_2Q0WS9\n}\n\nfragment DashboardPageActivity_query_2Q0WS9 on Query {\n  activity(days: 730, projectId: $projectId, repoId: $repoId) {\n    dailyActivity {\n      date\n      sessionCount\n      messageCount\n      inputTokens\n      outputTokens\n      cachedTokens\n      linesAdded\n      linesRemoved\n      filesChanged\n    }\n    hourlyActivity {\n      hour\n      sessionCount\n      messageCount\n    }\n    tokenUsage {\n      totalInputTokens\n      totalOutputTokens\n      totalCachedTokens\n      totalTokens\n      estimatedCostUsd\n      messageCount\n      sessionCount\n    }\n    dailyModelTokens {\n      date\n      models {\n        model\n        displayName\n        tokens\n      }\n      totalTokens\n    }\n    modelUsage {\n      model\n      displayName\n      inputTokens\n      outputTokens\n      cacheReadTokens\n      cacheCreationTokens\n      totalTokens\n      costUsd\n    }\n    totalSessions\n    totalMessages\n    firstSessionDate\n    streakDays\n    totalActiveDays\n  }\n}\n\nfragment DashboardPageAnalytics_query_2Q0WS9 on Query {\n  dashboardAnalytics(days: 30, projectId: $projectId, repoId: $repoId) {\n    subagentUsage {\n      subagentType\n      count\n    }\n    compactionStats {\n      totalCompactions\n      sessionsWithCompactions\n      sessionsWithoutCompactions\n      avgCompactionsPerSession\n      autoCompactCount\n      manualCompactCount\n      continuationCount\n    }\n    topSessions {\n      sessionId\n      slug\n      summary\n      score\n      sentimentTrend\n      avgSentimentScore\n      turnCount\n      taskCompletionRate\n      compactionCount\n      focusScore\n      startedAt\n    }\n    bottomSessions {\n      sessionId\n      slug\n      summary\n      score\n      sentimentTrend\n      avgSentimentScore\n      turnCount\n      taskCompletionRate\n      compactionCount\n      focusScore\n      startedAt\n    }\n    toolUsage {\n      toolName\n      count\n    }\n    hookHealth {\n      hookName\n      totalRuns\n      passCount\n      failCount\n      passRate\n      avgDurationMs\n    }\n    performanceTrend {\n      weekStart\n      weekLabel\n      sessionCount\n      avgTurns\n      avgCompactions\n      avgEffectiveness\n    }\n    costAnalysis {\n      estimatedCostUsd\n      isEstimated\n      billingType\n      cacheSavingsUsd\n      maxSubscriptionCostUsd\n      costUtilizationPercent\n      dailyCostTrend {\n        date\n        costUsd\n        sessionCount\n      }\n      weeklyCostTrend {\n        weekStart\n        weekLabel\n        costUsd\n        sessionCount\n        avgDailyCost\n      }\n      topSessionsByCost {\n        sessionId\n        slug\n        costUsd\n        inputTokens\n        outputTokens\n        cacheReadTokens\n        messageCount\n        startedAt\n      }\n      costPerSession\n      costPerCompletedTask\n      cacheHitRate\n      potentialSavingsUsd\n      subscriptionComparisons {\n        tierName\n        monthlyCostUsd\n        apiCreditCostUsd\n        savingsUsd\n        savingsPercent\n        recommendation\n      }\n      breakEvenDailySpend\n      configDirBreakdowns {\n        configDirId\n        configDirName\n        estimatedCostUsd\n        isEstimated\n        cacheSavingsUsd\n        totalSessions\n        totalMessages\n        modelCount\n        costPerSession\n        cacheHitRate\n        potentialSavingsUsd\n        costUtilizationPercent\n        dailyCostTrend {\n          date\n          costUsd\n          sessionCount\n        }\n        weeklyCostTrend {\n          weekStart\n          weekLabel\n          costUsd\n          sessionCount\n          avgDailyCost\n        }\n        subscriptionComparisons {\n          tierName\n          monthlyCostUsd\n          apiCreditCostUsd\n          savingsUsd\n          savingsPercent\n          recommendation\n        }\n        breakEvenDailySpend\n        topSessionsByCost {\n          sessionId\n          slug\n          costUsd\n          inputTokens\n          outputTokens\n          cacheReadTokens\n          messageCount\n          startedAt\n        }\n      }\n    }\n  }\n}\n\nfragment SessionListItem_session on Session {\n  id\n  sessionId\n  name\n  projectName\n  projectSlug\n  projectId\n  worktreeName\n  summary\n  messageCount\n  startedAt\n  updatedAt\n  owner {\n    id\n    name\n    email\n    avatarUrl\n  }\n  currentTodo {\n    content\n    activeForm\n    status\n    id\n  }\n  activeTasks {\n    totalCount\n    edges {\n      node {\n        id\n        taskId\n        description\n        type\n        status\n      }\n    }\n  }\n  todoCounts {\n    total\n    pending\n    inProgress\n    completed\n  }\n  gitBranch\n  prNumber\n  prUrl\n  teamName\n  turnCount\n  compactionCount\n  estimatedCostUsd\n  duration\n}\n"
+    "text": "query DashboardPageQuery(\n  $repoId: String!\n  $hasRepoId: Boolean!\n  $projectId: String!\n  $hasProjectId: Boolean!\n  $sessionFilter: SessionFilter\n) {\n  repo(id: $repoId) @include(if: $hasRepoId) {\n    name\n    id\n  }\n  project(id: $projectId) @include(if: $hasProjectId) {\n    id\n    projectId\n    name\n    totalSessions\n    lastActivity\n    worktrees {\n      name\n      path\n      sessionCount\n      isWorktree\n      subdirs {\n        relativePath\n        path\n        sessionCount\n        id\n      }\n      id\n    }\n    plugins {\n      id\n      name\n      marketplace\n      scope\n      enabled\n      category\n    }\n  }\n  projects(first: 100) {\n    id\n  }\n  sessions(first: 5, filter: $sessionFilter) {\n    edges {\n      node {\n        id\n        ...SessionListItem_session\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  metrics(period: WEEK, projectId: $projectId, repoId: $repoId) {\n    totalTasks\n    completedTasks\n    successRate\n    averageConfidence\n    calibrationScore\n    significantFrustrations\n    significantFrustrationRate\n  }\n  pluginStats {\n    totalPlugins\n    userPlugins\n    projectPlugins\n    localPlugins\n    enabledPlugins\n  }\n  pluginCategories {\n    category\n    count\n  }\n  ...DashboardPageActivity_query_2Q0WS9\n  ...DashboardPageAnalytics_query_2Q0WS9\n}\n\nfragment DashboardPageActivity_query_2Q0WS9 on Query {\n  activity(days: 730, projectId: $projectId, repoId: $repoId) {\n    dailyActivity {\n      date\n      sessionCount\n      messageCount\n      inputTokens\n      outputTokens\n      cachedTokens\n      linesAdded\n      linesRemoved\n      filesChanged\n    }\n    hourlyActivity {\n      hour\n      sessionCount\n      messageCount\n    }\n    tokenUsage {\n      totalInputTokens\n      totalOutputTokens\n      totalCachedTokens\n      totalTokens\n      estimatedCostUsd\n      messageCount\n      sessionCount\n    }\n    dailyModelTokens {\n      date\n      models {\n        model\n        displayName\n        tokens\n      }\n      totalTokens\n    }\n    modelUsage {\n      model\n      displayName\n      inputTokens\n      outputTokens\n      cacheReadTokens\n      cacheCreationTokens\n      totalTokens\n      costUsd\n    }\n    totalSessions\n    totalMessages\n    firstSessionDate\n    streakDays\n    totalActiveDays\n  }\n}\n\nfragment DashboardPageAnalytics_query_2Q0WS9 on Query {\n  dashboardAnalytics(days: 30, projectId: $projectId, repoId: $repoId) {\n    subagentUsage {\n      subagentType\n      count\n    }\n    compactionStats {\n      totalCompactions\n      sessionsWithCompactions\n      sessionsWithoutCompactions\n      avgCompactionsPerSession\n      autoCompactCount\n      manualCompactCount\n      continuationCount\n    }\n    topSessions {\n      sessionId\n      slug\n      summary\n      score\n      sentimentTrend\n      avgSentimentScore\n      turnCount\n      taskCompletionRate\n      compactionCount\n      focusScore\n      startedAt\n    }\n    bottomSessions {\n      sessionId\n      slug\n      summary\n      score\n      sentimentTrend\n      avgSentimentScore\n      turnCount\n      taskCompletionRate\n      compactionCount\n      focusScore\n      startedAt\n    }\n    toolUsage {\n      toolName\n      count\n    }\n    hookHealth {\n      hookName\n      totalRuns\n      passCount\n      failCount\n      passRate\n      avgDurationMs\n    }\n    performanceTrend {\n      weekStart\n      weekLabel\n      sessionCount\n      avgTurns\n      avgCompactions\n      avgEffectiveness\n    }\n    humanTimeEstimate {\n      totalHumanSeconds\n      totalAiSeconds\n      speedupFactor\n      hoursSaved\n      breakdown {\n        category\n        humanSeconds\n        percent\n      }\n      toolBreakdown {\n        toolName\n        invocations\n        humanSeconds\n      }\n    }\n    costAnalysis {\n      estimatedCostUsd\n      isEstimated\n      billingType\n      cacheSavingsUsd\n      maxSubscriptionCostUsd\n      costUtilizationPercent\n      dailyCostTrend {\n        date\n        costUsd\n        sessionCount\n      }\n      weeklyCostTrend {\n        weekStart\n        weekLabel\n        costUsd\n        sessionCount\n        avgDailyCost\n      }\n      topSessionsByCost {\n        sessionId\n        slug\n        costUsd\n        inputTokens\n        outputTokens\n        cacheReadTokens\n        messageCount\n        startedAt\n      }\n      costPerSession\n      costPerCompletedTask\n      cacheHitRate\n      potentialSavingsUsd\n      subscriptionComparisons {\n        tierName\n        monthlyCostUsd\n        apiCreditCostUsd\n        savingsUsd\n        savingsPercent\n        recommendation\n      }\n      breakEvenDailySpend\n      configDirBreakdowns {\n        configDirId\n        configDirName\n        estimatedCostUsd\n        isEstimated\n        cacheSavingsUsd\n        totalSessions\n        totalMessages\n        modelCount\n        costPerSession\n        cacheHitRate\n        potentialSavingsUsd\n        costUtilizationPercent\n        dailyCostTrend {\n          date\n          costUsd\n          sessionCount\n        }\n        weeklyCostTrend {\n          weekStart\n          weekLabel\n          costUsd\n          sessionCount\n          avgDailyCost\n        }\n        subscriptionComparisons {\n          tierName\n          monthlyCostUsd\n          apiCreditCostUsd\n          savingsUsd\n          savingsPercent\n          recommendation\n        }\n        breakEvenDailySpend\n        topSessionsByCost {\n          sessionId\n          slug\n          costUsd\n          inputTokens\n          outputTokens\n          cacheReadTokens\n          messageCount\n          startedAt\n        }\n      }\n    }\n  }\n}\n\nfragment SessionListItem_session on Session {\n  id\n  sessionId\n  name\n  projectName\n  projectSlug\n  projectId\n  worktreeName\n  summary\n  messageCount\n  startedAt\n  updatedAt\n  owner {\n    id\n    name\n    email\n    avatarUrl\n  }\n  currentTodo {\n    content\n    activeForm\n    status\n    id\n  }\n  activeTasks {\n    totalCount\n    edges {\n      node {\n        id\n        taskId\n        description\n        type\n        status\n      }\n    }\n  }\n  todoCounts {\n    total\n    pending\n    inProgress\n    completed\n  }\n  gitBranch\n  prNumber\n  prUrl\n  teamName\n  turnCount\n  compactionCount\n  estimatedCostUsd\n  duration\n}\n"
   }
 };
 })();

--- a/packages/browse-client/src/components/pages/DashboardPage/index.tsx
+++ b/packages/browse-client/src/components/pages/DashboardPage/index.tsx
@@ -86,6 +86,22 @@ export const DashboardAnalyticsFragment = graphql`
         avgCompactions
         avgEffectiveness
       }
+      humanTimeEstimate {
+        totalHumanSeconds
+        totalAiSeconds
+        speedupFactor
+        hoursSaved
+        breakdown {
+          category
+          humanSeconds
+          percent
+        }
+        toolBreakdown {
+          toolName
+          invocations
+          humanSeconds
+        }
+      }
       costAnalysis {
         estimatedCostUsd
         isEstimated

--- a/packages/han-rs/crates/han-api/src/query.rs
+++ b/packages/han-rs/crates/han-api/src/query.rs
@@ -2275,62 +2275,88 @@ impl QueryRoot {
         }
 
         // Query 1: Total human time and AI wall-clock duration
+        // AI duration = SUM of per-session durations (max - min timestamp within each session),
+        // NOT the span from oldest to newest message across all sessions (which would be ~30 days).
         let (ht_total_sql, ht_total_values) = if let Some((ref sc, ref sv)) = scope {
             (
                 format!(
                     "SELECT \
                      COALESCE(SUM(human_time_ms), 0) as total_human_ms, \
-                     COALESCE((julianday(MAX(timestamp)) - julianday(MIN(timestamp))) * 86400.0, 0.0) as ai_duration_seconds \
+                     COALESCE(( \
+                       SELECT SUM(session_dur) FROM ( \
+                         SELECT (julianday(MAX(timestamp)) - julianday(MIN(timestamp))) * 86400.0 as session_dur \
+                         FROM messages \
+                         WHERE timestamp >= date('now', ? || ' days') AND {sc} \
+                         GROUP BY session_id \
+                         HAVING COUNT(*) > 1 \
+                       ) \
+                     ), 0.0) as ai_duration_seconds \
                      FROM messages \
                      WHERE timestamp >= date('now', ? || ' days') AND {sc}"
                 ),
-                vec![format!("-{days}").into(), sv.clone()],
+                vec![format!("-{days}").into(), sv.clone(), format!("-{days}").into(), sv.clone()],
             )
         } else {
             (
                 "SELECT \
                  COALESCE(SUM(human_time_ms), 0) as total_human_ms, \
-                 COALESCE((julianday(MAX(timestamp)) - julianday(MIN(timestamp))) * 86400.0, 0.0) as ai_duration_seconds \
+                 COALESCE(( \
+                   SELECT SUM(session_dur) FROM ( \
+                     SELECT (julianday(MAX(timestamp)) - julianday(MIN(timestamp))) * 86400.0 as session_dur \
+                     FROM messages \
+                     WHERE timestamp >= date('now', ? || ' days') \
+                     GROUP BY session_id \
+                     HAVING COUNT(*) > 1 \
+                   ) \
+                 ), 0.0) as ai_duration_seconds \
                  FROM messages \
                  WHERE timestamp >= date('now', ? || ' days')"
                     .to_string(),
-                vec![format!("-{days}").into()],
+                vec![format!("-{days}").into(), format!("-{days}").into()],
             )
         };
 
-        // Query 2: Breakdown by message_type category
+        // Query 2: Breakdown by category
+        // Split assistant messages into "Reading AI Output" (token-based) and "Writing Code" (lines-based)
+        // using UNION ALL to compute each sub-category from the raw columns.
+        let cat_core = |where_clause: &str| format!(
+            "SELECT 'Reading AI Output' as category, \
+               COALESCE(SUM(CAST(output_tokens AS BIGINT) * 320), 0) as category_ms \
+             FROM messages WHERE message_type = 'assistant' AND output_tokens IS NOT NULL AND {where_clause} \
+             UNION ALL \
+             SELECT 'Writing Code' as category, \
+               COALESCE(SUM(CAST(lines_added AS BIGINT) * 12000), 0) as category_ms \
+             FROM messages WHERE message_type = 'assistant' AND lines_added IS NOT NULL AND lines_added > 0 AND {where_clause} \
+             UNION ALL \
+             SELECT 'Thinking & Deciding' as category, \
+               COALESCE(SUM(human_time_ms), 0) as category_ms \
+             FROM messages WHERE message_type = 'user' AND human_time_ms IS NOT NULL AND {where_clause} \
+             UNION ALL \
+             SELECT 'Navigation & Tools' as category, \
+               COALESCE(SUM(human_time_ms), 0) as category_ms \
+             FROM messages WHERE message_type = 'tool_use' AND human_time_ms IS NOT NULL AND {where_clause}"
+        );
         let (ht_cat_sql, ht_cat_values) = if let Some((ref sc, ref sv)) = scope {
+            let w = format!("timestamp >= date('now', ? || ' days') AND {sc}");
             (
-                format!(
-                    "SELECT \
-                     CASE \
-                       WHEN message_type = 'assistant' THEN 'Reading AI Output' \
-                       WHEN message_type = 'user' THEN 'Thinking & Deciding' \
-                       WHEN message_type = 'tool_use' THEN 'Navigation & Tools' \
-                       ELSE 'Other' \
-                     END as category, \
-                     COALESCE(SUM(human_time_ms), 0) as category_ms \
-                     FROM messages \
-                     WHERE human_time_ms IS NOT NULL AND timestamp >= date('now', ? || ' days') AND {sc} \
-                     GROUP BY category"
-                ),
-                vec![format!("-{days}").into(), sv.clone()],
+                cat_core(&w),
+                vec![
+                    format!("-{days}").into(), sv.clone(),
+                    format!("-{days}").into(), sv.clone(),
+                    format!("-{days}").into(), sv.clone(),
+                    format!("-{days}").into(), sv.clone(),
+                ],
             )
         } else {
+            let w = "timestamp >= date('now', ? || ' days')";
             (
-                "SELECT \
-                 CASE \
-                   WHEN message_type = 'assistant' THEN 'Reading AI Output' \
-                   WHEN message_type = 'user' THEN 'Thinking & Deciding' \
-                   WHEN message_type = 'tool_use' THEN 'Navigation & Tools' \
-                   ELSE 'Other' \
-                 END as category, \
-                 COALESCE(SUM(human_time_ms), 0) as category_ms \
-                 FROM messages \
-                 WHERE human_time_ms IS NOT NULL AND timestamp >= date('now', ? || ' days') \
-                 GROUP BY category"
-                    .to_string(),
-                vec![format!("-{days}").into()],
+                cat_core(w),
+                vec![
+                    format!("-{days}").into(),
+                    format!("-{days}").into(),
+                    format!("-{days}").into(),
+                    format!("-{days}").into(),
+                ],
             )
         };
 
@@ -2345,7 +2371,7 @@ impl QueryRoot {
                      FROM messages \
                      WHERE message_type = 'tool_use' AND human_time_ms IS NOT NULL \
                        AND timestamp >= date('now', ? || ' days') AND {sc} \
-                     GROUP BY tool_name ORDER BY tool_ms DESC"
+                     GROUP BY tool_name ORDER BY tool_ms DESC LIMIT 15"
                 ),
                 vec![format!("-{days}").into(), sv.clone()],
             )
@@ -2358,7 +2384,7 @@ impl QueryRoot {
                  FROM messages \
                  WHERE message_type = 'tool_use' AND human_time_ms IS NOT NULL \
                    AND timestamp >= date('now', ? || ' days') \
-                 GROUP BY tool_name ORDER BY tool_ms DESC"
+                 GROUP BY tool_name ORDER BY tool_ms DESC LIMIT 15"
                     .to_string(),
                 vec![format!("-{days}").into()],
             )
@@ -2423,7 +2449,7 @@ impl QueryRoot {
                 .filter(|r| r.tool_ms > 0)
                 .map(|r| ToolTimeEstimate {
                     tool_name: Some(r.tool_name.clone()),
-                    invocations: Some(r.invocations as i32),
+                    invocations: Some(i32::try_from(r.invocations).unwrap_or(i32::MAX)),
                     human_seconds: Some((r.tool_ms as f64 / 1000.0 * 10.0).round() / 10.0),
                 })
                 .collect();

--- a/packages/han-rs/crates/han-api/src/query.rs
+++ b/packages/han-rs/crates/han-api/src/query.rs
@@ -26,8 +26,9 @@ use crate::types::config_dir::ConfigDir;
 use crate::types::dashboard::{
     estimate_cost_for_model, estimate_cost_usd, model_display_name, ActivityData,
     CoordinatorStatus, CostAnalysis, DailyActivity, DailyCost, DailyModelTokens,
-    DashboardAnalytics, HookHealthStats, HourlyActivity, ModelTokenEntry, ModelUsageStats,
-    SessionCost, SessionPerformancePoint, StatsCache, TokenUsageStats, ToolUsageStats, WeeklyCost,
+    DashboardAnalytics, HookHealthStats, HourlyActivity, HumanTimeBreakdown, HumanTimeEstimate,
+    ModelTokenEntry, ModelUsageStats, SessionCost, SessionPerformancePoint, StatsCache,
+    TokenUsageStats, ToolTimeEstimate, ToolUsageStats, WeeklyCost,
 };
 use crate::types::enums::MetricsPeriod;
 use crate::types::metrics::{MetricsData, TaskOutcomeCount, TaskTypeCount};
@@ -2247,6 +2248,175 @@ impl QueryRoot {
                 .collect::<Vec<_>>()
         };
 
+        // ====================================================================
+        // Phase 6: Human Time Estimation
+        // ====================================================================
+        //
+        // Estimates how long a human developer would take to produce the same
+        // output, based on realistic performance benchmarks:
+        //   - Reading AI output:   250 WPM → ~0.32s per output token (4 chars/token)
+        //   - Writing/typing code: 40 WPM  → 12s per line added
+        //   - File navigation:     15-45s per tool call depending on type
+        //   - Cognitive overhead:   120s per user turn (decision point)
+        //   - Manual search:        30s per grep/glob invocation
+        //
+        // Constants (seconds):
+        const SECS_PER_OUTPUT_TOKEN_READ: f64 = 0.32; // 250 WPM reading, ~0.75 words/token
+        const SECS_PER_LINE_ADDED: f64 = 12.0; // 40 WPM, ~8 words/line
+        const SECS_PER_USER_TURN: f64 = 120.0; // thinking + deciding next step
+        const SECS_FILE_READ: f64 = 15.0; // open + navigate to file
+        const SECS_FILE_WRITE: f64 = 30.0; // create file + navigate
+        const SECS_FILE_EDIT: f64 = 45.0; // find location + understand context
+        const SECS_BASH_CMD: f64 = 20.0; // type + execute + read output
+        const SECS_SEARCH: f64 = 30.0; // manual grep/find equivalent
+        const SECS_WEB_SEARCH: f64 = 60.0; // browser + query + scan results
+        const SECS_AGENT: f64 = 60.0; // delegation + context switch
+        const SECS_OTHER_TOOL: f64 = 15.0; // generic tool overhead
+
+        #[derive(Debug, FromQueryResult)]
+        struct HumanTimeRow {
+            total_output_tokens: i64,
+            total_lines_added: i64,
+            user_turn_count: i64,
+            read_calls: i64,
+            write_calls: i64,
+            edit_calls: i64,
+            bash_calls: i64,
+            search_calls: i64,
+            web_calls: i64,
+            agent_calls: i64,
+            other_tool_calls: i64,
+            ai_duration_seconds: f64,
+        }
+
+        let (ht_sql, ht_values) = if let Some((ref sc, ref sv)) = scope {
+            (
+                format!(
+                    "SELECT \
+                     COALESCE(SUM(CASE WHEN message_type = 'assistant' THEN output_tokens ELSE 0 END), 0) as total_output_tokens, \
+                     COALESCE(SUM(lines_added), 0) as total_lines_added, \
+                     COUNT(DISTINCT CASE WHEN role = 'user' THEN id END) as user_turn_count, \
+                     SUM(CASE WHEN tool_name = 'Read' THEN 1 ELSE 0 END) as read_calls, \
+                     SUM(CASE WHEN tool_name = 'Write' THEN 1 ELSE 0 END) as write_calls, \
+                     SUM(CASE WHEN tool_name IN ('Edit', 'NotebookEdit') THEN 1 ELSE 0 END) as edit_calls, \
+                     SUM(CASE WHEN tool_name = 'Bash' THEN 1 ELSE 0 END) as bash_calls, \
+                     SUM(CASE WHEN tool_name IN ('Grep', 'Glob') THEN 1 ELSE 0 END) as search_calls, \
+                     SUM(CASE WHEN tool_name IN ('WebSearch', 'WebFetch') THEN 1 ELSE 0 END) as web_calls, \
+                     SUM(CASE WHEN tool_name IN ('Agent', 'Task') THEN 1 ELSE 0 END) as agent_calls, \
+                     SUM(CASE WHEN tool_name IS NOT NULL AND tool_name NOT IN ('Read','Write','Edit','NotebookEdit','Bash','Grep','Glob','WebSearch','WebFetch','Agent','Task','TodoWrite') THEN 1 ELSE 0 END) as other_tool_calls, \
+                     COALESCE((julianday(MAX(timestamp)) - julianday(MIN(timestamp))) * 86400.0, 0.0) as ai_duration_seconds \
+                     FROM messages \
+                     WHERE timestamp >= date('now', ? || ' days') AND {sc}"
+                ),
+                vec![format!("-{days}").into(), sv.clone()],
+            )
+        } else {
+            (
+                "SELECT \
+                 COALESCE(SUM(CASE WHEN message_type = 'assistant' THEN output_tokens ELSE 0 END), 0) as total_output_tokens, \
+                 COALESCE(SUM(lines_added), 0) as total_lines_added, \
+                 COUNT(DISTINCT CASE WHEN role = 'user' THEN id END) as user_turn_count, \
+                 SUM(CASE WHEN tool_name = 'Read' THEN 1 ELSE 0 END) as read_calls, \
+                 SUM(CASE WHEN tool_name = 'Write' THEN 1 ELSE 0 END) as write_calls, \
+                 SUM(CASE WHEN tool_name IN ('Edit', 'NotebookEdit') THEN 1 ELSE 0 END) as edit_calls, \
+                 SUM(CASE WHEN tool_name = 'Bash' THEN 1 ELSE 0 END) as bash_calls, \
+                 SUM(CASE WHEN tool_name IN ('Grep', 'Glob') THEN 1 ELSE 0 END) as search_calls, \
+                 SUM(CASE WHEN tool_name IN ('WebSearch', 'WebFetch') THEN 1 ELSE 0 END) as web_calls, \
+                 SUM(CASE WHEN tool_name IN ('Agent', 'Task') THEN 1 ELSE 0 END) as agent_calls, \
+                 SUM(CASE WHEN tool_name IS NOT NULL AND tool_name NOT IN ('Read','Write','Edit','NotebookEdit','Bash','Grep','Glob','WebSearch','WebFetch','Agent','Task','TodoWrite') THEN 1 ELSE 0 END) as other_tool_calls, \
+                 COALESCE((julianday(MAX(timestamp)) - julianday(MIN(timestamp))) * 86400.0, 0.0) as ai_duration_seconds \
+                 FROM messages \
+                 WHERE timestamp >= date('now', ? || ' days')"
+                    .to_string(),
+                vec![format!("-{days}").into()],
+            )
+        };
+
+        let human_time_estimate =
+            HumanTimeRow::find_by_statement(Statement::from_sql_and_values(
+                DbBackend::Sqlite,
+                ht_sql,
+                ht_values,
+            ))
+            .one(db)
+            .await
+            .unwrap_or(None)
+            .map(|row| {
+                // Calculate time per category
+                let reading_secs = row.total_output_tokens as f64 * SECS_PER_OUTPUT_TOKEN_READ;
+                let writing_secs = row.total_lines_added as f64 * SECS_PER_LINE_ADDED;
+                let thinking_secs = row.user_turn_count as f64 * SECS_PER_USER_TURN;
+                let navigation_secs = row.read_calls as f64 * SECS_FILE_READ
+                    + row.write_calls as f64 * SECS_FILE_WRITE
+                    + row.edit_calls as f64 * SECS_FILE_EDIT
+                    + row.bash_calls as f64 * SECS_BASH_CMD
+                    + row.search_calls as f64 * SECS_SEARCH
+                    + row.web_calls as f64 * SECS_WEB_SEARCH
+                    + row.agent_calls as f64 * SECS_AGENT
+                    + row.other_tool_calls as f64 * SECS_OTHER_TOOL;
+
+                let total_human_secs = reading_secs + writing_secs + thinking_secs + navigation_secs;
+                let ai_secs = row.ai_duration_seconds;
+                let speedup = if ai_secs > 0.0 {
+                    total_human_secs / ai_secs
+                } else {
+                    0.0
+                };
+                let hours_saved = ((total_human_secs - ai_secs) / 3600.0).max(0.0);
+
+                // Build breakdown
+                let mut breakdown = vec![];
+                let categories = [
+                    ("Reading AI Output", reading_secs),
+                    ("Writing Code", writing_secs),
+                    ("Thinking & Deciding", thinking_secs),
+                    ("Navigation & Tools", navigation_secs),
+                ];
+                for (cat, secs) in &categories {
+                    if *secs > 0.0 {
+                        breakdown.push(HumanTimeBreakdown {
+                            category: Some(cat.to_string()),
+                            human_seconds: Some((*secs * 10.0).round() / 10.0),
+                            percent: Some(if total_human_secs > 0.0 {
+                                (*secs / total_human_secs * 100.0).round()
+                            } else {
+                                0.0
+                            }),
+                        });
+                    }
+                }
+
+                // Build per-tool breakdown
+                let tool_entries = [
+                    ("Read", row.read_calls, row.read_calls as f64 * SECS_FILE_READ),
+                    ("Write", row.write_calls, row.write_calls as f64 * SECS_FILE_WRITE),
+                    ("Edit", row.edit_calls, row.edit_calls as f64 * SECS_FILE_EDIT),
+                    ("Bash", row.bash_calls, row.bash_calls as f64 * SECS_BASH_CMD),
+                    ("Search", row.search_calls, row.search_calls as f64 * SECS_SEARCH),
+                    ("Web", row.web_calls, row.web_calls as f64 * SECS_WEB_SEARCH),
+                    ("Agent", row.agent_calls, row.agent_calls as f64 * SECS_AGENT),
+                    ("Other", row.other_tool_calls, row.other_tool_calls as f64 * SECS_OTHER_TOOL),
+                ];
+                let tool_breakdown: Vec<ToolTimeEstimate> = tool_entries
+                    .iter()
+                    .filter(|(_, count, _)| *count > 0)
+                    .map(|(name, count, secs)| ToolTimeEstimate {
+                        tool_name: Some(name.to_string()),
+                        invocations: Some(*count as i32),
+                        human_seconds: Some((*secs * 10.0).round() / 10.0),
+                    })
+                    .collect();
+
+                HumanTimeEstimate {
+                    total_human_seconds: Some((total_human_secs * 10.0).round() / 10.0),
+                    total_ai_seconds: Some((ai_secs * 10.0).round() / 10.0),
+                    speedup_factor: Some((speedup * 10.0).round() / 10.0),
+                    hours_saved: Some((hours_saved * 100.0).round() / 100.0),
+                    breakdown: Some(breakdown),
+                    tool_breakdown: Some(tool_breakdown),
+                }
+            });
+
         let result = DashboardAnalytics {
             top_sessions: Some(top_sessions),
             bottom_sessions: Some(bottom_sessions),
@@ -2256,6 +2426,7 @@ impl QueryRoot {
             subagent_usage: Some(subagent_usage),
             tool_usage: Some(tool_usage),
             performance_trend: Some(performance_trend),
+            human_time_estimate,
         };
 
         // Cache the result for 30 seconds

--- a/packages/han-rs/crates/han-api/src/query.rs
+++ b/packages/han-rs/crates/han-api/src/query.rs
@@ -2249,61 +2249,37 @@ impl QueryRoot {
         };
 
         // ====================================================================
-        // Phase 6: Human Time Estimation
+        // Phase 6: Human Time Estimation (from pre-computed human_time_ms)
         // ====================================================================
         //
-        // Estimates how long a human developer would take to produce the same
-        // output, based on realistic performance benchmarks:
-        //   - Reading AI output:   250 WPM → ~0.32s per output token (4 chars/token)
-        //   - Writing/typing code: 40 WPM  → 12s per line added
-        //   - File navigation:     15-45s per tool call depending on type
-        //   - Cognitive overhead:   120s per user turn (decision point)
-        //   - Manual search:        30s per grep/glob invocation
-        //
-        // Constants (seconds):
-        const SECS_PER_OUTPUT_TOKEN_READ: f64 = 0.32; // 250 WPM reading, ~0.75 words/token
-        const SECS_PER_LINE_ADDED: f64 = 12.0; // 40 WPM, ~8 words/line
-        const SECS_PER_USER_TURN: f64 = 120.0; // thinking + deciding next step
-        const SECS_FILE_READ: f64 = 15.0; // open + navigate to file
-        const SECS_FILE_WRITE: f64 = 30.0; // create file + navigate
-        const SECS_FILE_EDIT: f64 = 45.0; // find location + understand context
-        const SECS_BASH_CMD: f64 = 20.0; // type + execute + read output
-        const SECS_SEARCH: f64 = 30.0; // manual grep/find equivalent
-        const SECS_WEB_SEARCH: f64 = 60.0; // browser + query + scan results
-        const SECS_AGENT: f64 = 60.0; // delegation + context switch
-        const SECS_OTHER_TOOL: f64 = 15.0; // generic tool overhead
+        // human_time_ms is computed per-message at index time by the indexer.
+        // Here we aggregate via SUM and group for breakdowns.
 
         #[derive(Debug, FromQueryResult)]
-        struct HumanTimeRow {
-            total_output_tokens: i64,
-            total_lines_added: i64,
-            user_turn_count: i64,
-            read_calls: i64,
-            write_calls: i64,
-            edit_calls: i64,
-            bash_calls: i64,
-            search_calls: i64,
-            web_calls: i64,
-            agent_calls: i64,
-            other_tool_calls: i64,
+        struct HumanTimeTotalRow {
+            total_human_ms: i64,
             ai_duration_seconds: f64,
         }
 
-        let (ht_sql, ht_values) = if let Some((ref sc, ref sv)) = scope {
+        #[derive(Debug, FromQueryResult)]
+        struct HumanTimeByTypeRow {
+            category: String,
+            category_ms: i64,
+        }
+
+        #[derive(Debug, FromQueryResult)]
+        struct HumanTimeByToolRow {
+            tool_name: String,
+            invocations: i64,
+            tool_ms: i64,
+        }
+
+        // Query 1: Total human time and AI wall-clock duration
+        let (ht_total_sql, ht_total_values) = if let Some((ref sc, ref sv)) = scope {
             (
                 format!(
                     "SELECT \
-                     COALESCE(SUM(CASE WHEN message_type = 'assistant' THEN output_tokens ELSE 0 END), 0) as total_output_tokens, \
-                     COALESCE(SUM(lines_added), 0) as total_lines_added, \
-                     COUNT(DISTINCT CASE WHEN role = 'user' THEN id END) as user_turn_count, \
-                     SUM(CASE WHEN tool_name = 'Read' THEN 1 ELSE 0 END) as read_calls, \
-                     SUM(CASE WHEN tool_name = 'Write' THEN 1 ELSE 0 END) as write_calls, \
-                     SUM(CASE WHEN tool_name IN ('Edit', 'NotebookEdit') THEN 1 ELSE 0 END) as edit_calls, \
-                     SUM(CASE WHEN tool_name = 'Bash' THEN 1 ELSE 0 END) as bash_calls, \
-                     SUM(CASE WHEN tool_name IN ('Grep', 'Glob') THEN 1 ELSE 0 END) as search_calls, \
-                     SUM(CASE WHEN tool_name IN ('WebSearch', 'WebFetch') THEN 1 ELSE 0 END) as web_calls, \
-                     SUM(CASE WHEN tool_name IN ('Agent', 'Task') THEN 1 ELSE 0 END) as agent_calls, \
-                     SUM(CASE WHEN tool_name IS NOT NULL AND tool_name NOT IN ('Read','Write','Edit','NotebookEdit','Bash','Grep','Glob','WebSearch','WebFetch','Agent','Task','TodoWrite') THEN 1 ELSE 0 END) as other_tool_calls, \
+                     COALESCE(SUM(human_time_ms), 0) as total_human_ms, \
                      COALESCE((julianday(MAX(timestamp)) - julianday(MIN(timestamp))) * 86400.0, 0.0) as ai_duration_seconds \
                      FROM messages \
                      WHERE timestamp >= date('now', ? || ' days') AND {sc}"
@@ -2313,17 +2289,7 @@ impl QueryRoot {
         } else {
             (
                 "SELECT \
-                 COALESCE(SUM(CASE WHEN message_type = 'assistant' THEN output_tokens ELSE 0 END), 0) as total_output_tokens, \
-                 COALESCE(SUM(lines_added), 0) as total_lines_added, \
-                 COUNT(DISTINCT CASE WHEN role = 'user' THEN id END) as user_turn_count, \
-                 SUM(CASE WHEN tool_name = 'Read' THEN 1 ELSE 0 END) as read_calls, \
-                 SUM(CASE WHEN tool_name = 'Write' THEN 1 ELSE 0 END) as write_calls, \
-                 SUM(CASE WHEN tool_name IN ('Edit', 'NotebookEdit') THEN 1 ELSE 0 END) as edit_calls, \
-                 SUM(CASE WHEN tool_name = 'Bash' THEN 1 ELSE 0 END) as bash_calls, \
-                 SUM(CASE WHEN tool_name IN ('Grep', 'Glob') THEN 1 ELSE 0 END) as search_calls, \
-                 SUM(CASE WHEN tool_name IN ('WebSearch', 'WebFetch') THEN 1 ELSE 0 END) as web_calls, \
-                 SUM(CASE WHEN tool_name IN ('Agent', 'Task') THEN 1 ELSE 0 END) as agent_calls, \
-                 SUM(CASE WHEN tool_name IS NOT NULL AND tool_name NOT IN ('Read','Write','Edit','NotebookEdit','Bash','Grep','Glob','WebSearch','WebFetch','Agent','Task','TodoWrite') THEN 1 ELSE 0 END) as other_tool_calls, \
+                 COALESCE(SUM(human_time_ms), 0) as total_human_ms, \
                  COALESCE((julianday(MAX(timestamp)) - julianday(MIN(timestamp))) * 86400.0, 0.0) as ai_duration_seconds \
                  FROM messages \
                  WHERE timestamp >= date('now', ? || ' days')"
@@ -2332,90 +2298,145 @@ impl QueryRoot {
             )
         };
 
-        let human_time_estimate =
-            HumanTimeRow::find_by_statement(Statement::from_sql_and_values(
-                DbBackend::Sqlite,
-                ht_sql,
-                ht_values,
-            ))
-            .one(db)
-            .await
-            .unwrap_or(None)
-            .map(|row| {
-                // Calculate time per category
-                let reading_secs = row.total_output_tokens as f64 * SECS_PER_OUTPUT_TOKEN_READ;
-                let writing_secs = row.total_lines_added as f64 * SECS_PER_LINE_ADDED;
-                let thinking_secs = row.user_turn_count as f64 * SECS_PER_USER_TURN;
-                let navigation_secs = row.read_calls as f64 * SECS_FILE_READ
-                    + row.write_calls as f64 * SECS_FILE_WRITE
-                    + row.edit_calls as f64 * SECS_FILE_EDIT
-                    + row.bash_calls as f64 * SECS_BASH_CMD
-                    + row.search_calls as f64 * SECS_SEARCH
-                    + row.web_calls as f64 * SECS_WEB_SEARCH
-                    + row.agent_calls as f64 * SECS_AGENT
-                    + row.other_tool_calls as f64 * SECS_OTHER_TOOL;
+        // Query 2: Breakdown by message_type category
+        let (ht_cat_sql, ht_cat_values) = if let Some((ref sc, ref sv)) = scope {
+            (
+                format!(
+                    "SELECT \
+                     CASE \
+                       WHEN message_type = 'assistant' THEN 'Reading AI Output' \
+                       WHEN message_type = 'user' THEN 'Thinking & Deciding' \
+                       WHEN message_type = 'tool_use' THEN 'Navigation & Tools' \
+                       ELSE 'Other' \
+                     END as category, \
+                     COALESCE(SUM(human_time_ms), 0) as category_ms \
+                     FROM messages \
+                     WHERE human_time_ms IS NOT NULL AND timestamp >= date('now', ? || ' days') AND {sc} \
+                     GROUP BY category"
+                ),
+                vec![format!("-{days}").into(), sv.clone()],
+            )
+        } else {
+            (
+                "SELECT \
+                 CASE \
+                   WHEN message_type = 'assistant' THEN 'Reading AI Output' \
+                   WHEN message_type = 'user' THEN 'Thinking & Deciding' \
+                   WHEN message_type = 'tool_use' THEN 'Navigation & Tools' \
+                   ELSE 'Other' \
+                 END as category, \
+                 COALESCE(SUM(human_time_ms), 0) as category_ms \
+                 FROM messages \
+                 WHERE human_time_ms IS NOT NULL AND timestamp >= date('now', ? || ' days') \
+                 GROUP BY category"
+                    .to_string(),
+                vec![format!("-{days}").into()],
+            )
+        };
 
-                let total_human_secs = reading_secs + writing_secs + thinking_secs + navigation_secs;
-                let ai_secs = row.ai_duration_seconds;
-                let speedup = if ai_secs > 0.0 {
-                    total_human_secs / ai_secs
-                } else {
-                    0.0
-                };
-                let hours_saved = ((total_human_secs - ai_secs) / 3600.0).max(0.0);
+        // Query 3: Per-tool breakdown for tool_use messages
+        let (ht_tool_sql, ht_tool_values) = if let Some((ref sc, ref sv)) = scope {
+            (
+                format!(
+                    "SELECT \
+                     COALESCE(tool_name, 'Unknown') as tool_name, \
+                     COUNT(*) as invocations, \
+                     COALESCE(SUM(human_time_ms), 0) as tool_ms \
+                     FROM messages \
+                     WHERE message_type = 'tool_use' AND human_time_ms IS NOT NULL \
+                       AND timestamp >= date('now', ? || ' days') AND {sc} \
+                     GROUP BY tool_name ORDER BY tool_ms DESC"
+                ),
+                vec![format!("-{days}").into(), sv.clone()],
+            )
+        } else {
+            (
+                "SELECT \
+                 COALESCE(tool_name, 'Unknown') as tool_name, \
+                 COUNT(*) as invocations, \
+                 COALESCE(SUM(human_time_ms), 0) as tool_ms \
+                 FROM messages \
+                 WHERE message_type = 'tool_use' AND human_time_ms IS NOT NULL \
+                   AND timestamp >= date('now', ? || ' days') \
+                 GROUP BY tool_name ORDER BY tool_ms DESC"
+                    .to_string(),
+                vec![format!("-{days}").into()],
+            )
+        };
 
-                // Build breakdown
-                let mut breakdown = vec![];
-                let categories = [
-                    ("Reading AI Output", reading_secs),
-                    ("Writing Code", writing_secs),
-                    ("Thinking & Deciding", thinking_secs),
-                    ("Navigation & Tools", navigation_secs),
-                ];
-                for (cat, secs) in &categories {
-                    if *secs > 0.0 {
-                        breakdown.push(HumanTimeBreakdown {
-                            category: Some(cat.to_string()),
-                            human_seconds: Some((*secs * 10.0).round() / 10.0),
-                            percent: Some(if total_human_secs > 0.0 {
-                                (*secs / total_human_secs * 100.0).round()
-                            } else {
-                                0.0
-                            }),
-                        });
+        let total_row = HumanTimeTotalRow::find_by_statement(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            ht_total_sql,
+            ht_total_values,
+        ))
+        .one(db)
+        .await
+        .unwrap_or(None);
+
+        let cat_rows = HumanTimeByTypeRow::find_by_statement(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            ht_cat_sql,
+            ht_cat_values,
+        ))
+        .all(db)
+        .await
+        .unwrap_or_default();
+
+        let tool_rows = HumanTimeByToolRow::find_by_statement(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            ht_tool_sql,
+            ht_tool_values,
+        ))
+        .all(db)
+        .await
+        .unwrap_or_default();
+
+        let human_time_estimate = total_row.map(|row| {
+            let total_human_secs = row.total_human_ms as f64 / 1000.0;
+            let ai_secs = row.ai_duration_seconds;
+            let speedup = if ai_secs > 0.0 {
+                total_human_secs / ai_secs
+            } else {
+                0.0
+            };
+            let hours_saved = ((total_human_secs - ai_secs) / 3600.0).max(0.0);
+
+            let breakdown: Vec<HumanTimeBreakdown> = cat_rows
+                .iter()
+                .filter(|r| r.category_ms > 0)
+                .map(|r| {
+                    let secs = r.category_ms as f64 / 1000.0;
+                    HumanTimeBreakdown {
+                        category: Some(r.category.clone()),
+                        human_seconds: Some((secs * 10.0).round() / 10.0),
+                        percent: Some(if total_human_secs > 0.0 {
+                            (secs / total_human_secs * 100.0).round()
+                        } else {
+                            0.0
+                        }),
                     }
-                }
+                })
+                .collect();
 
-                // Build per-tool breakdown
-                let tool_entries = [
-                    ("Read", row.read_calls, row.read_calls as f64 * SECS_FILE_READ),
-                    ("Write", row.write_calls, row.write_calls as f64 * SECS_FILE_WRITE),
-                    ("Edit", row.edit_calls, row.edit_calls as f64 * SECS_FILE_EDIT),
-                    ("Bash", row.bash_calls, row.bash_calls as f64 * SECS_BASH_CMD),
-                    ("Search", row.search_calls, row.search_calls as f64 * SECS_SEARCH),
-                    ("Web", row.web_calls, row.web_calls as f64 * SECS_WEB_SEARCH),
-                    ("Agent", row.agent_calls, row.agent_calls as f64 * SECS_AGENT),
-                    ("Other", row.other_tool_calls, row.other_tool_calls as f64 * SECS_OTHER_TOOL),
-                ];
-                let tool_breakdown: Vec<ToolTimeEstimate> = tool_entries
-                    .iter()
-                    .filter(|(_, count, _)| *count > 0)
-                    .map(|(name, count, secs)| ToolTimeEstimate {
-                        tool_name: Some(name.to_string()),
-                        invocations: Some(*count as i32),
-                        human_seconds: Some((*secs * 10.0).round() / 10.0),
-                    })
-                    .collect();
+            let tool_breakdown: Vec<ToolTimeEstimate> = tool_rows
+                .iter()
+                .filter(|r| r.tool_ms > 0)
+                .map(|r| ToolTimeEstimate {
+                    tool_name: Some(r.tool_name.clone()),
+                    invocations: Some(r.invocations as i32),
+                    human_seconds: Some((r.tool_ms as f64 / 1000.0 * 10.0).round() / 10.0),
+                })
+                .collect();
 
-                HumanTimeEstimate {
-                    total_human_seconds: Some((total_human_secs * 10.0).round() / 10.0),
-                    total_ai_seconds: Some((ai_secs * 10.0).round() / 10.0),
-                    speedup_factor: Some((speedup * 10.0).round() / 10.0),
-                    hours_saved: Some((hours_saved * 100.0).round() / 100.0),
-                    breakdown: Some(breakdown),
-                    tool_breakdown: Some(tool_breakdown),
-                }
-            });
+            HumanTimeEstimate {
+                total_human_seconds: Some((total_human_secs * 10.0).round() / 10.0),
+                total_ai_seconds: Some((ai_secs * 10.0).round() / 10.0),
+                speedup_factor: Some((speedup * 10.0).round() / 10.0),
+                hours_saved: Some((hours_saved * 100.0).round() / 100.0),
+                breakdown: Some(breakdown),
+                tool_breakdown: Some(tool_breakdown),
+            }
+        });
 
         let result = DashboardAnalytics {
             top_sessions: Some(top_sessions),

--- a/packages/han-rs/crates/han-api/src/types/dashboard.rs
+++ b/packages/han-rs/crates/han-api/src/types/dashboard.rs
@@ -113,6 +113,7 @@ pub struct DashboardAnalytics {
     pub subagent_usage: Option<Vec<SubagentUsageStats>>,
     pub tool_usage: Option<Vec<ToolUsageStats>>,
     pub performance_trend: Option<Vec<SessionPerformancePoint>>,
+    pub human_time_estimate: Option<HumanTimeEstimate>,
 }
 
 /// Weekly session performance data point for trend visualization.
@@ -268,6 +269,56 @@ pub struct SubagentUsageStats {
 pub struct ToolUsageStats {
     pub tool_name: Option<String>,
     pub count: Option<i32>,
+}
+
+// ============================================================================
+// Human Time Estimation
+// ============================================================================
+
+/// Human-equivalent time estimation for AI-completed work.
+///
+/// Estimates how long a human developer would take to perform the same
+/// actions that AI completed, based on realistic human performance benchmarks:
+/// - Reading: 250 words per minute (~187 tokens/min)
+/// - Typing code: 40 words per minute (~30 tokens/min)
+/// - File navigation: 15–45 seconds per operation
+/// - Cognitive overhead: 2 minutes per decision point
+#[derive(Debug, Clone, SimpleObject)]
+pub struct HumanTimeEstimate {
+    /// Total estimated human time in seconds.
+    pub total_human_seconds: Option<f64>,
+    /// Total actual AI time in seconds (wall clock).
+    pub total_ai_seconds: Option<f64>,
+    /// Speedup factor (human_time / ai_time).
+    pub speedup_factor: Option<f64>,
+    /// Human hours saved (human_time - ai_time), clamped to 0.
+    pub hours_saved: Option<f64>,
+    /// Breakdown by activity category.
+    pub breakdown: Option<Vec<HumanTimeBreakdown>>,
+    /// Per-tool-category time estimates.
+    pub tool_breakdown: Option<Vec<ToolTimeEstimate>>,
+}
+
+/// Time breakdown by activity category.
+#[derive(Debug, Clone, SimpleObject)]
+pub struct HumanTimeBreakdown {
+    /// Category label (e.g., "Reading AI Output", "Writing Code", "Searching").
+    pub category: Option<String>,
+    /// Estimated human seconds for this category.
+    pub human_seconds: Option<f64>,
+    /// Percentage of total human time.
+    pub percent: Option<f64>,
+}
+
+/// Per-tool-category human time estimate.
+#[derive(Debug, Clone, SimpleObject)]
+pub struct ToolTimeEstimate {
+    /// Tool name or category.
+    pub tool_name: Option<String>,
+    /// Number of invocations.
+    pub invocations: Option<i32>,
+    /// Total estimated human seconds for all invocations of this tool.
+    pub human_seconds: Option<f64>,
 }
 
 // ============================================================================
@@ -433,6 +484,7 @@ impl Default for DashboardAnalytics {
             subagent_usage: Some(vec![]),
             tool_usage: Some(vec![]),
             performance_trend: Some(vec![]),
+            human_time_estimate: None,
         }
     }
 }

--- a/packages/han-rs/crates/han-api/src/types/messages/mod.rs
+++ b/packages/han-rs/crates/han-api/src/types/messages/mod.rs
@@ -2094,6 +2094,7 @@ mod tests {
             lines_added: None,
             lines_removed: None,
             files_changed: None,
+            human_time_ms: None,
             indexed_at: None,
         }
     }

--- a/packages/han-rs/crates/han-db/src/crud/messages.rs
+++ b/packages/han-rs/crates/han-db/src/crud/messages.rs
@@ -240,6 +240,7 @@ fn rows_to_models(rows: Vec<sea_orm::QueryResult>) -> DbResult<Vec<messages::Mod
             lines_added: row.try_get("", "lines_added").ok(),
             lines_removed: row.try_get("", "lines_removed").ok(),
             files_changed: row.try_get("", "files_changed").ok(),
+            human_time_ms: row.try_get("", "human_time_ms").ok(),
             indexed_at: row.try_get("", "indexed_at").ok(),
         });
     }

--- a/packages/han-rs/crates/han-db/src/entities/messages.rs
+++ b/packages/han-rs/crates/han-db/src/entities/messages.rs
@@ -37,6 +37,7 @@ pub struct Model {
     pub lines_added: Option<i32>,
     pub lines_removed: Option<i32>,
     pub files_changed: Option<i32>,
+    pub human_time_ms: Option<i32>,
     pub indexed_at: Option<String>,
 }
 

--- a/packages/han-rs/crates/han-db/src/migration.rs
+++ b/packages/han-rs/crates/han-db/src/migration.rs
@@ -5,6 +5,7 @@ pub mod m20260215_000002_team_entities;
 pub mod m20260220_add_session_pr_team;
 pub mod m20260222_tool_call_results;
 pub mod m20260223_performance_indexes;
+pub mod m20260401_human_time_estimation;
 
 use sea_orm::DatabaseConnection;
 use sea_orm_migration::prelude::*;
@@ -20,6 +21,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260220_add_session_pr_team::Migration),
             Box::new(m20260222_tool_call_results::Migration),
             Box::new(m20260223_performance_indexes::Migration),
+            Box::new(m20260401_human_time_estimation::Migration),
         ]
     }
 }

--- a/packages/han-rs/crates/han-db/src/migration/m20260401_human_time_estimation.rs
+++ b/packages/han-rs/crates/han-db/src/migration/m20260401_human_time_estimation.rs
@@ -1,0 +1,66 @@
+//! Migration: Add human_time_ms to messages and indexer_version to han_metadata.
+//!
+//! - `human_time_ms` stores per-message human-equivalent time in milliseconds
+//! - `indexer_version` in han_metadata enables auto-reindex when estimation logic changes
+//! - Resets last_indexed_line on all sessions and session_files to force re-indexing
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add human_time_ms column to messages
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Messages::Table)
+                    .add_column(ColumnDef::new(Messages::HumanTimeMs).integer().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        // Force full re-index so human_time_ms gets populated for existing messages
+        let db = manager.get_connection();
+        db.execute_unprepared("UPDATE sessions SET last_indexed_line = 0")
+            .await?;
+        db.execute_unprepared("UPDATE session_files SET last_indexed_line = 0")
+            .await?;
+
+        // Seed indexer_version in han_metadata (used for future reindex triggers)
+        db.execute_unprepared(
+            "INSERT OR REPLACE INTO han_metadata (key, value, updated_at) \
+             VALUES ('indexer_version', '1', datetime('now'))",
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Remove indexer_version
+        let db = manager.get_connection();
+        db.execute_unprepared("DELETE FROM han_metadata WHERE key = 'indexer_version'")
+            .await?;
+
+        // SQLite 3.35+ supports ALTER TABLE DROP COLUMN
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Messages::Table)
+                    .drop_column(Messages::HumanTimeMs)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Messages {
+    Table,
+    HumanTimeMs,
+}

--- a/packages/han-rs/crates/han-db/tests/integration_test.rs
+++ b/packages/han-rs/crates/han-db/tests/integration_test.rs
@@ -357,6 +357,7 @@ async fn test_messages_crud() {
             lines_added: Set(None),
             lines_removed: Set(None),
             files_changed: Set(None),
+            human_time_ms: Set(None),
             indexed_at: Set(None),
         },
         msg_entity::ActiveModel {
@@ -386,6 +387,7 @@ async fn test_messages_crud() {
             lines_added: Set(None),
             lines_removed: Set(None),
             files_changed: Set(None),
+            human_time_ms: Set(None),
             indexed_at: Set(None),
         },
         msg_entity::ActiveModel {
@@ -415,6 +417,7 @@ async fn test_messages_crud() {
             lines_added: Set(Some(5)),
             lines_removed: Set(Some(3)),
             files_changed: Set(Some(1)),
+            human_time_ms: Set(None),
             indexed_at: Set(None),
         },
     ];
@@ -933,6 +936,7 @@ async fn test_fts5_search_messages() {
             lines_added: Set(None),
             lines_removed: Set(None),
             files_changed: Set(None),
+            human_time_ms: Set(None),
             indexed_at: Set(None),
         },
         msg_entity::ActiveModel {
@@ -962,6 +966,7 @@ async fn test_fts5_search_messages() {
             lines_added: Set(None),
             lines_removed: Set(None),
             files_changed: Set(None),
+            human_time_ms: Set(None),
             indexed_at: Set(None),
         },
     ];
@@ -1062,6 +1067,7 @@ async fn test_dashboard_aggregates() {
             lines_added: Set(None),
             lines_removed: Set(None),
             files_changed: Set(None),
+            human_time_ms: Set(None),
             indexed_at: Set(None),
         },
         msg_entity::ActiveModel {
@@ -1091,6 +1097,7 @@ async fn test_dashboard_aggregates() {
             lines_added: Set(None),
             lines_removed: Set(None),
             files_changed: Set(None),
+            human_time_ms: Set(None),
             indexed_at: Set(None),
         },
     ];
@@ -1166,6 +1173,7 @@ async fn test_activity_aggregates() {
         lines_added: Set(Some(10)),
         lines_removed: Set(Some(3)),
         files_changed: Set(Some(2)),
+        human_time_ms: Set(None),
         indexed_at: Set(None),
     }];
 

--- a/packages/han-rs/crates/han-indexer/src/lib.rs
+++ b/packages/han-rs/crates/han-indexer/src/lib.rs
@@ -23,7 +23,8 @@ pub mod watcher;
 // Re-export primary public API
 pub use parser::{jsonl_count_lines, jsonl_read_page, jsonl_read_reverse, JsonlLine, PaginatedResult};
 pub use processor::{
-    full_scan_and_index, handle_file_event, index_project_directory, index_session_file,
+    check_indexer_version, full_scan_and_index, handle_file_event, index_project_directory,
+    index_session_file, INDEXER_VERSION,
 };
 pub use sentiment::{analyze_sentiment, FrustrationLevel, SentimentLevel, SentimentResult};
 pub use task_timeline::{TaskTimeRange, TaskTimeline};

--- a/packages/han-rs/crates/han-indexer/src/processor.rs
+++ b/packages/han-rs/crates/han-indexer/src/processor.rs
@@ -46,6 +46,55 @@ pub enum ProcessorError {
 
 pub type ProcessorResult<T> = Result<T, ProcessorError>;
 
+/// Check if the indexer version has changed and trigger re-indexing if needed.
+///
+/// Compares `INDEXER_VERSION` against `han_metadata.indexer_version`. When the
+/// stored version differs (or is missing), resets `last_indexed_line` to 0 on
+/// all sessions and session_files, then updates the stored version. This ensures
+/// that changes to indexing logic (like new computed columns) are retroactively
+/// applied to all existing data.
+pub async fn check_indexer_version(db: &DatabaseConnection) -> ProcessorResult<bool> {
+    // Read current stored version
+    let row = db
+        .query_one(Statement::from_string(
+            DbBackend::Sqlite,
+            "SELECT value FROM han_metadata WHERE key = 'indexer_version'".to_string(),
+        ))
+        .await
+        .map_err(|e| ProcessorError::Other(e.to_string()))?;
+
+    let stored_version = row.and_then(|r| r.try_get::<String>("", "value").ok());
+
+    if stored_version.as_deref() == Some(INDEXER_VERSION) {
+        return Ok(false); // No change needed
+    }
+
+    // Version mismatch — trigger full re-index
+    tracing::info!(
+        old = ?stored_version,
+        new = INDEXER_VERSION,
+        "Indexer version changed, triggering full re-index"
+    );
+
+    db.execute_unprepared("UPDATE sessions SET last_indexed_line = 0")
+        .await
+        .map_err(|e| ProcessorError::Other(e.to_string()))?;
+    db.execute_unprepared("UPDATE session_files SET last_indexed_line = 0")
+        .await
+        .map_err(|e| ProcessorError::Other(e.to_string()))?;
+
+    // Update stored version
+    db.execute_unprepared(&format!(
+        "INSERT OR REPLACE INTO han_metadata (key, value, updated_at) \
+         VALUES ('indexer_version', '{}', datetime('now'))",
+        INDEXER_VERSION
+    ))
+    .await
+    .map_err(|e| ProcessorError::Other(e.to_string()))?;
+
+    Ok(true) // Re-index triggered
+}
+
 // ============================================================================
 // JSONL Parsing helpers
 // ============================================================================
@@ -224,7 +273,7 @@ fn finalize_parsed_message(
         (None, None, None)
     };
 
-    Some(ParsedMessage {
+    let mut msg = ParsedMessage {
         message_type,
         role,
         content,
@@ -243,8 +292,11 @@ fn finalize_parsed_message(
         lines_added,
         lines_removed,
         files_changed,
+        human_time_ms: None,
         compact_type,
-    })
+    };
+    msg.human_time_ms = estimate_human_time_ms(&msg);
+    Some(msg)
 }
 
 /// Extract message content from various JSON structures.
@@ -439,6 +491,60 @@ fn extract_line_changes(json: &Value) -> (Option<i32>, Option<i32>, Option<i32>)
         )
     } else {
         (None, None, None)
+    }
+}
+
+/// Indexer version — bump this to trigger automatic re-indexing of all sessions.
+/// The coordinator checks this against `han_metadata.indexer_version` at startup.
+pub const INDEXER_VERSION: &str = "1";
+
+/// Estimate human-equivalent time in milliseconds for a single message.
+///
+/// Uses realistic human performance benchmarks:
+/// - Reading: 250 WPM → ~0.32s per output token (4 chars/token, 0.75 words/token)
+/// - Typing code: 40 WPM → ~12s per line added
+/// - User turn (thinking/deciding): 120s per turn
+/// - Tool navigation overhead: 15-60s depending on tool type
+///
+/// Returns `None` for message types that don't contribute (progress, system, etc.).
+pub fn estimate_human_time_ms(parsed: &ParsedMessage) -> Option<i32> {
+    match parsed.message_type {
+        MessageType::Assistant => {
+            let mut ms: f64 = 0.0;
+
+            // Reading time: output_tokens * 0.32s/token → ms
+            if let Some(output_tokens) = parsed.output_tokens {
+                ms += output_tokens as f64 * 320.0; // 0.32s * 1000ms
+            }
+
+            // Typing time: lines_added * 12s/line → ms
+            if let Some(lines_added) = parsed.lines_added {
+                ms += lines_added as f64 * 12_000.0;
+            }
+
+            if ms > 0.0 { Some(ms as i32) } else { None }
+        }
+        MessageType::User => {
+            // Each user turn = 120s of thinking/deciding next step
+            Some(120_000) // 120s in ms
+        }
+        MessageType::ToolUse => {
+            // Per-tool navigation/execution overhead
+            let tool = parsed.tool_name.as_deref().unwrap_or("");
+            let secs = match tool {
+                "Read" => 15.0,
+                "Write" => 30.0,
+                "Edit" | "NotebookEdit" => 45.0,
+                "Bash" => 20.0,
+                "Grep" | "Glob" => 30.0,
+                "WebSearch" | "WebFetch" => 60.0,
+                "Agent" | "Task" => 60.0,
+                "TodoWrite" | "TodoRead" => 0.0, // No human equivalent
+                _ => 15.0,
+            };
+            if secs > 0.0 { Some((secs * 1000.0) as i32) } else { None }
+        }
+        _ => None,
     }
 }
 
@@ -1233,6 +1339,7 @@ fn to_active_model(
     lines_added: Option<i32>,
     lines_removed: Option<i32>,
     files_changed: Option<i32>,
+    human_time_ms: Option<i32>,
 ) -> messages::ActiveModel {
     messages::ActiveModel {
         id: Set(id),
@@ -1261,6 +1368,7 @@ fn to_active_model(
         lines_added: Set(lines_added),
         lines_removed: Set(lines_removed),
         files_changed: Set(files_changed),
+        human_time_ms: Set(human_time_ms),
         indexed_at: Set(Some(Utc::now().to_rfc3339())),
     }
 }
@@ -1563,6 +1671,30 @@ pub async fn index_session_file(
                                         let tool_input_str = item
                                             .get("input")
                                             .map(|v| v.to_string());
+                                        // Estimate human time for this tool_use
+                                        let tool_use_msg = ParsedMessage {
+                                            message_type: MessageType::ToolUse,
+                                            role: Some("assistant".to_string()),
+                                            content: None,
+                                            tool_name: Some(tool_name.to_string()),
+                                            tool_input: tool_input_str.clone(),
+                                            tool_result: None,
+                                            raw_json: String::new(),
+                                            timestamp: finalized.timestamp.clone(),
+                                            uuid: tool_use_id.clone(),
+                                            agent_id: finalized.agent_id.clone(),
+                                            parent_id: Some(message_id.clone()),
+                                            input_tokens: None,
+                                            output_tokens: None,
+                                            cache_read_tokens: None,
+                                            cache_creation_tokens: None,
+                                            lines_added: None,
+                                            lines_removed: None,
+                                            files_changed: None,
+                                            human_time_ms: None,
+                                            compact_type: None,
+                                        };
+                                        let tool_human_time = estimate_human_time_ms(&tool_use_msg);
                                         messages_batch.push(to_active_model(
                                             tool_use_id,
                                             &session_id,
@@ -1582,6 +1714,7 @@ pub async fn index_session_file(
                                             None, None, None, None,
                                             None, None, None, None,
                                             None, None, None,
+                                            tool_human_time,
                                         ));
                                     }
                                 }
@@ -1685,6 +1818,7 @@ pub async fn index_session_file(
                 finalized.lines_added,
                 finalized.lines_removed,
                 finalized.files_changed,
+                finalized.human_time_ms,
             ));
 
             // NOTE: Separate sentiment_analysis events are no longer generated.
@@ -1759,6 +1893,7 @@ pub async fn index_session_file(
                 None,
                 None,
                 None,
+                None, // human_time_ms
             ));
 
             if messages_batch.len() >= 100 {
@@ -1938,6 +2073,7 @@ fn generate_sentiment_event(
         None,
         None,
         None,
+        None, // human_time_ms
     ))
 }
 
@@ -2179,6 +2315,9 @@ pub async fn handle_file_event(
 
 /// Perform a full scan and index of all Claude Code sessions.
 pub async fn full_scan_and_index(db: &DatabaseConnection) -> ProcessorResult<Vec<IndexResult>> {
+    // Check if indexer version changed — triggers full re-index if needed
+    let _ = check_indexer_version(db).await;
+
     let mut results = Vec::new();
 
     let config_dirs = crud::config_dirs::list(db).await?;

--- a/packages/han-rs/crates/han-indexer/src/processor.rs
+++ b/packages/han-rs/crates/han-indexer/src/processor.rs
@@ -84,10 +84,11 @@ pub async fn check_indexer_version(db: &DatabaseConnection) -> ProcessorResult<b
         .map_err(|e| ProcessorError::Other(e.to_string()))?;
 
     // Update stored version
-    db.execute_unprepared(&format!(
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
         "INSERT OR REPLACE INTO han_metadata (key, value, updated_at) \
-         VALUES ('indexer_version', '{}', datetime('now'))",
-        INDEXER_VERSION
+         VALUES ('indexer_version', $1, datetime('now'))",
+        vec![INDEXER_VERSION.into()],
     ))
     .await
     .map_err(|e| ProcessorError::Other(e.to_string()))?;
@@ -496,7 +497,7 @@ fn extract_line_changes(json: &Value) -> (Option<i32>, Option<i32>, Option<i32>)
 
 /// Indexer version — bump this to trigger automatic re-indexing of all sessions.
 /// The coordinator checks this against `han_metadata.indexer_version` at startup.
-pub const INDEXER_VERSION: &str = "1";
+pub const INDEXER_VERSION: &str = "2";
 
 /// Estimate human-equivalent time in milliseconds for a single message.
 ///
@@ -525,8 +526,12 @@ pub fn estimate_human_time_ms(parsed: &ParsedMessage) -> Option<i32> {
             if ms > 0.0 { Some(ms as i32) } else { None }
         }
         MessageType::User => {
-            // Each user turn = 120s of thinking/deciding next step
-            Some(120_000) // 120s in ms
+            // Scale by content length: short confirmations ("y", "ok") get less time,
+            // longer prompts with context get more. Clamp between 5s and 120s.
+            let content_len = parsed.content.as_ref().map(|c| c.len()).unwrap_or(0);
+            // ~0.5s per character, clamped
+            let secs = (content_len as f64 * 0.5).clamp(5.0, 120.0);
+            Some((secs * 1000.0) as i32)
         }
         MessageType::ToolUse => {
             // Per-tool navigation/execution overhead

--- a/packages/han-rs/crates/han-indexer/src/types.rs
+++ b/packages/han-rs/crates/han-indexer/src/types.rs
@@ -106,6 +106,7 @@ pub struct ParsedMessage {
     pub lines_added: Option<i32>,
     pub lines_removed: Option<i32>,
     pub files_changed: Option<i32>,
+    pub human_time_ms: Option<i32>,
     pub compact_type: Option<String>,
 }
 


### PR DESCRIPTION
## Summary

Adds human-equivalent time estimation to the dashboard analytics, showing how long a human developer would take to perform the same work that AI completed. Includes a new `HumanTimeCard` component that displays speedup factors, time breakdowns by activity category, and per-tool navigation overhead.

## Changes

- **New Component**: `HumanTimeCard.tsx` - Displays human time estimation with:
  - Total estimated human time vs actual AI time comparison bar
  - Speedup factor badge (color-coded by magnitude)
  - Hours saved calculation
  - Activity category breakdown (Reading AI Output, Writing Code, Thinking & Deciding, Navigation & Tools)
  - Per-tool navigation overhead breakdown
  - Human performance benchmarks callout

- **Indexer Changes**:
  - Added `human_time_ms` column to messages table to store per-message human-equivalent time
  - Implemented `estimate_human_time_ms()` function using realistic benchmarks:
    - Reading: 250 WPM (~0.32s per output token)
    - Typing code: 40 WPM (~12s per line added)
    - User turns: 120s per decision point
    - Tool navigation: 15-60s depending on tool type
  - Added `INDEXER_VERSION` constant and `check_indexer_version()` to trigger automatic re-indexing when estimation logic changes
  - Created migration `m20260401_human_time_estimation` to add column and reset indexing state

- **API Changes**:
  - Added `HumanTimeEstimate`, `HumanTimeBreakdown`, and `ToolTimeEstimate` types to GraphQL schema
  - Implemented aggregation queries in `query.rs` to compute:
    - Total human vs AI time
    - Breakdown by message type category
    - Per-tool invocation counts and time
  - Added `human_time_estimate` field to `DashboardAnalytics`

- **Dashboard Integration**:
  - Updated `DashboardContent.tsx` to render `HumanTimeCard` in a new "Human Time Estimation (30 days)" section
  - Updated GraphQL fragments to query new `humanTimeEstimate` fields
  - Regenerated GraphQL type definitions

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation
- [ ] New plugin

## Testing

- Existing GraphQL and database tests pass
- New migration tested with schema changes
- Component renders correctly with sample data
- No new warnings introduced

## Checklist

- [x] Code follows existing patterns
- [x] Self-review completed
- [x] GraphQL schema and types properly defined
- [x] Database migration included
- [x] No new warnings

https://claude.ai/code/session_01Bdi46VcwoE5tqeE3mW2sqG