### PR TITLE
fix(core): remove WorktreeCreate hook that breaks worktree-isolated agents

### DIFF
--- a/plugins/core/hooks/hooks.json
+++ b/plugins/core/hooks/hooks.json
@@ -118,17 +118,6 @@
         ]
       }
     ],
-    "WorktreeCreate": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook dispatch WorktreeCreate",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
     "WorktreeRemove": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

- Removes the `WorktreeCreate` registration from `plugins/core/hooks/hooks.json`, which was causing every worktree-isolated agent launch to fail with `WorktreeCreate hook failed: no successful output`.

## Root cause

Claude Code's `WorktreeCreate` hook has replace-default semantics (see Han's own docs at `website/content/docs/cli/hooks.md:406`):

> When a WorktreeCreate hook is configured, it **replaces the default git worktree behavior** […] The hook receives a `name` slug and **must print the absolute path** to the created worktree directory on stdout. A non-zero exit code blocks worktree creation.

The core plugin was pre-registering `han hook dispatch WorktreeCreate` so that plugins could opt into handling the event via the `event:` field in `han-plugin.yml`. That dispatch pattern works fine for observational events (`ConfigChange`, `TaskCompleted`, `SessionEnd`, `WorktreeRemove`, etc.), because Claude Code doesn't require output from those. It does **not** work for `WorktreeCreate`:

1. No Han plugin currently implements a `WorktreeCreate` handler (I grepped — `plugins/core/hooks/hooks.json` is the only reference in the repo).
2. `han hook dispatch WorktreeCreate` therefore produces no output.
3. Claude Code interprets silence as "hook failed: no successful output" and blocks the agent launch.

Net effect: any agent with `isolation: worktree` in its frontmatter — `security-engineer`, `code-reviewer`, and other specialist agents from the `do/` plugins — fails immediately. This renders the review disciplines (`/review-pr`, `/review-mr`, `/security-review`) broken whenever they spawn isolated specialists.

## Why just delete the registration

Three options were considered:

1. **Remove the registration** (this PR). Claude Code falls back to its default `git worktree add` behavior. Plugins that want custom WorktreeCreate semantics — e.g. for SVN/Perforce/Mercurial — can register their own hook directly in their own `hooks.json`; they need to produce a path on stdout, which the generic dispatcher cannot guarantee anyway.
2. **Smart fallback inside the dispatcher**: if no plugin produces output, run `git worktree add <path>` ourselves and print the path. Preserves the opt-in mechanism but duplicates Claude Code's default logic (path conventions, error handling, non-git-repo cases) and is much riskier than just letting Claude Code do what it already does correctly.
3. **Leave as-is**: not an option — it actively breaks the product.

Option 1 is the minimal, safe fix. `WorktreeRemove` is left in place because it is observational per Claude Code's docs ("cannot block" removal), so a silent no-op there is harmless.

## Repro

1. Install `core@han`.
2. Invoke any agent with `isolation: worktree` (e.g. `security-engineer` via `/security-review` or `/review-mr`).
3. Observe: `Error: WorktreeCreate hook failed: no successful output`.

After this fix: the agent launches, Claude Code creates the worktree with the built-in `git worktree add`, and specialist agents work again.

## Test plan

- [ ] Pull the branch, run a review skill that spawns worktree-isolated specialists (e.g. `/review-pr` or `/security-review`) and confirm agents launch successfully.
- [ ] Confirm `git worktree list` shows the expected worktree created by Claude Code's default path.
- [ ] Confirm no regression in other hook events (`ConfigChange`, `TaskCompleted`, `WorktreeRemove`, etc.) — unchanged by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)