### PR TITLE
fix(install): correct Windows asset name and .exe suffix

### DIFF
--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -49,7 +49,8 @@ detect_platform() {
 		esac
 		;;
 	MINGW* | MSYS* | CYGWIN*)
-		echo "win32-x64"
+		# Match the release asset naming (han-windows-x64.exe).
+		echo "windows-x64"
 		;;
 	*)
 		echo -e "${RED}Unsupported operating system: $os${NC}" >&2
@@ -59,6 +60,17 @@ detect_platform() {
 }
 
 PLATFORM=$(detect_platform)
+
+# Windows binaries are published with a .exe suffix; everything else is bare.
+case "$PLATFORM" in
+windows-*)
+	BINARY_SUFFIX=".exe"
+	HAN_BIN="${HAN_BIN}.exe"
+	;;
+*)
+	BINARY_SUFFIX=""
+	;;
+esac
 
 # Get latest version from GitHub API
 echo -e "${YELLOW}Fetching latest version...${NC}"
@@ -86,7 +98,7 @@ fi
 
 echo -e "${GREEN}Installing han v$LATEST_VERSION...${NC}"
 
-DOWNLOAD_URL="https://github.com/TheBushidoCollective/han/releases/download/v${LATEST_VERSION}/han-${PLATFORM}"
+DOWNLOAD_URL="https://github.com/TheBushidoCollective/han/releases/download/v${LATEST_VERSION}/han-${PLATFORM}${BINARY_SUFFIX}"
 CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
 
 # Download to temp files first for atomic replacement


### PR DESCRIPTION
## Summary

Curl install on Windows currently 404s. \`install.sh\` detects Windows as \`win32-x64\` and downloads \`han-win32-x64\` from the latest release, but the release workflow publishes the Windows binary as \`han-windows-x64.exe\`. Match the asset name and append \`.exe\` to both the download URL and the local binary path so the install lands at \`~/.local/bin/han.exe\` and runs.

## Test plan

- [ ] On Git Bash / MSYS / Cygwin, run \`curl -fsSL https://han.guru/install.sh | bash\` and verify it downloads without a 404 and writes \`~/.local/bin/han.exe\`.
- [ ] On macOS / Linux, re-run the installer and verify behavior is unchanged (no \`.exe\` suffix, \`darwin-*\` / \`linux-*\` asset names).

## Scope

Refs #90. This handles the install script naming portion only. The TTY-no-output behavior of the Bun-compiled \`han.exe\` (output works through pipes but not in a Windows console) is a separate Bun-on-Windows bug; that part of #90 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)