### PR TITLE
feat(antigravity): add Han bridge for Google Antigravity IDE via MCP

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1025,6 +1025,21 @@
       ]
     },
     {
+      "name": "antigravity",
+      "description": "Bridge plugin that enables Han's hook ecosystem (validation, skills, disciplines) to work with Google Antigravity IDE via MCP server.",
+      "source": "./plugins/bridges/antigravity",
+      "category": "Integration",
+      "keywords": [
+        "antigravity",
+        "google",
+        "bridge",
+        "mcp",
+        "hooks",
+        "validation",
+        "skills"
+      ]
+    },
+    {
       "name": "performance-engineering",
       "description": "Performance engineering agents providing expertise in profiling, optimization, and scalability",
       "source": "./plugins/disciplines/performance-engineering",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2632,6 +2632,21 @@
       ]
     },
     {
+      "name": "hashi-antigravity",
+      "description": "Bridge plugin that enables Han's hook ecosystem (validation, skills, disciplines) to work with Google Antigravity IDE via MCP server.",
+      "source": "./plugins/bridges/antigravity",
+      "category": "Integration",
+      "keywords": [
+        "antigravity",
+        "google",
+        "bridge",
+        "mcp",
+        "hooks",
+        "validation",
+        "skills"
+      ]
+    },
+    {
       "name": "hashi-playwright-mcp",
       "description": "MCP server configuration for Playwright integration providing test automation, browser control, and test execution capabilities.",
       "source": "./plugins/services/playwright-mcp",

--- a/packages/han/lib/plugin-aliases.ts
+++ b/packages/han/lib/plugin-aliases.ts
@@ -162,6 +162,7 @@ export const PLUGIN_ALIASES: Record<string, string> = {
   'hashi-opencode': 'bridges/opencode',
   'hashi-kiro': 'bridges/kiro',
   'hashi-codex': 'bridges/codex',
+  'hashi-antigravity': 'bridges/antigravity',
 
   // services
   'hashi-agent-sop': 'services/agent-sop',

--- a/plugins/bridges/antigravity/.claude-plugin/plugin.json
+++ b/plugins/bridges/antigravity/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "antigravity",
+  "version": "0.1.0",
+  "description": "Bridge plugin that enables Han's hook ecosystem (validation, skills, disciplines) to work with Google Antigravity IDE via MCP server.",
+  "author": {
+    "name": "The Bushido Collective",
+    "url": "https://thebushido.co"
+  },
+  "homepage": "https://github.com/thebushidocollective/han",
+  "repository": "https://github.com/thebushidocollective/han",
+  "license": "Apache-2.0",
+  "keywords": [
+    "antigravity",
+    "google",
+    "bridge",
+    "mcp",
+    "hooks",
+    "validation",
+    "skills"
+  ]
+}

--- a/plugins/bridges/antigravity/README.md
+++ b/plugins/bridges/antigravity/README.md
@@ -1,0 +1,188 @@
+# Han Bridge for Google Antigravity
+
+MCP server that brings Han's full plugin ecosystem to [Google Antigravity](https://antigravity.google/) IDE -- 400+ skills, 25 agent disciplines, and on-demand validation hooks.
+
+## What This Does
+
+Han plugins define validation hooks, specialized skills, and agent disciplines that run during Claude Code sessions. This bridge makes the entire ecosystem work in Antigravity via MCP:
+
+1. **Skills** -- 400+ coding skills loadable on demand via `han_skills` tool
+2. **Disciplines** -- 25 agent personas (frontend, backend, SRE, security, etc.)
+3. **Validation** -- On-demand linting, type checking, and formatting via `han_validate`
+4. **Sync** -- Copy skills and rules to `.agent/` for native Antigravity discovery
+5. **Context** -- Current time and session state via `han_context`
+6. **Events** -- Unified JSONL logging with `provider: "antigravity"` for Browse UI
+
+## How It Works
+
+Unlike the OpenCode bridge (which hooks into JS plugin events), Antigravity doesn't have lifecycle hooks. Instead, this bridge runs as an MCP server and exposes Han's capabilities as tools:
+
+| Tool | Purpose | Replaces |
+|------|---------|----------|
+| `han_skills` | Browse/load 400+ skills | Native skill discovery |
+| `han_discipline` | Activate agent personas | System prompt injection |
+| `han_validate` | Run validation hooks | PostToolUse/Stop hooks |
+| `han_sync` | Sync skills/rules to .agent/ | SessionStart setup |
+| `han_context` | Get time + active discipline | UserPromptSubmit context |
+
+## Validation Modes
+
+### Per-File Validation (After Edits)
+
+```
+Agent: han_validate({ mode: "file", files: ["src/app.ts"], tool: "Edit" })
+→ Runs matching PostToolUse hooks (biome, eslint, tsc)
+→ Returns structured results with pass/fail per hook
+```
+
+### Project-Wide Validation (Before Finishing)
+
+```
+Agent: han_validate({ mode: "project" })
+→ Runs all Stop hooks (full project lint, typecheck, tests)
+→ Returns comprehensive validation summary
+```
+
+## Setup
+
+### Prerequisites
+
+Han plugins must be installed:
+
+```bash
+curl -fsSL https://han.guru/install.sh | bash
+han plugin install --auto
+```
+
+### Add MCP Server
+
+Add to `~/.gemini/antigravity/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "han": {
+      "command": "npx",
+      "args": ["-y", "antigravity-han-mcp"]
+    }
+  }
+}
+```
+
+### Optional: Sync Skills Natively
+
+After setup, ask the agent to sync Han skills for native Antigravity discovery:
+
+```
+> Run han_sync to set up Han skills
+```
+
+This copies skills to `.agent/skills/` and creates `.agent/rules/han-guidelines.md`.
+
+## Architecture
+
+```
+Google Antigravity IDE
+  |
+  |-- mcp_config.json ─────────────────────> Han MCP Server
+  |     (stdio transport)                       |
+  |                                             |
+  |-- han_skills ──────────────────────────> Skill discovery
+  |     (LLM-callable tool)                    (list/search/load 400+ skills)
+  |                                             |
+  |-- han_discipline ──────────────────────> Agent disciplines
+  |     (LLM-callable tool)                    (activate/deactivate/list)
+  |                                             |
+  |-- han_validate ────────────────────────> Hook executor
+  |     (LLM-callable tool)                    |
+  |     mode="file"  ──> PostToolUse hooks     |
+  |     mode="project" ──> Stop hooks          |
+  |                                             |
+  |-- han_sync ────────────────────────────> Filesystem sync
+  |     (LLM-callable tool)                    |
+  |     skills → .agent/skills/                |
+  |     rules  → .agent/rules/                 |
+  |                                             |
+  |-- han_context ─────────────────────────> Session state
+  |     (LLM-callable tool)                    (time, discipline, stats)
+  |                                             |
+  |-- .agent/rules/han-guidelines.md ──────> Core guidelines
+  |     (native Antigravity rules)              (synced by han_sync)
+  |                                             |
+  |-- .agent/skills/han-*/SKILL.md ────────> Native skills
+  |     (native Antigravity skills)             (synced by han_sync)
+  |                                             |
+  |-- JSONL logger ────────────────────────> Event logging
+        (hook_run, hook_result)                 (Browse UI visibility)
+
+Bridge Internals:
+  index.ts         MCP server entry point (JSON-RPC over stdio)
+  discovery.ts     Read settings + marketplace + resolve plugin paths
+  skills.ts        Discover SKILL.md files from installed plugins
+  disciplines.ts   Discover discipline plugins, context builder
+  context.ts       Core guidelines + datetime for rules/context
+  sync.ts          Copy skills/rules to .agent/ directory
+  matcher.ts       Filter hooks by tool name, file globs, dirsWith
+  executor.ts      Spawn hook commands as parallel promises
+  formatter.ts     Structure results for MCP tool responses
+  events.ts        JSONL event logger (provider="antigravity")
+  cache.ts         Content-hash caching (SHA-256)
+```
+
+## Comparison with OpenCode Bridge
+
+| Feature | OpenCode Bridge | Antigravity Bridge |
+|---------|----------------|-------------------|
+| Integration | JS plugin API (events) | MCP server (tools) |
+| Validation trigger | Automatic (tool.execute.after) | On-demand (han_validate) |
+| Context injection | experimental.chat.system.transform | .agent/rules/ + han_context |
+| Skill discovery | han_skills tool | han_skills tool + .agent/skills/ sync |
+| Stop validation | Automatic (session.idle/stop) | On-demand (han_validate mode=project) |
+| Event logging | provider: "opencode" | provider: "antigravity" |
+
+## Remaining Gaps
+
+These are genuine platform limitations in Antigravity (as of Feb 2026):
+
+- **Automatic validation**: No lifecycle hooks, so validation requires explicit han_validate calls
+- **Permission denial**: Cannot block tool execution (no PreToolUse equivalent)
+- **Subagent hooks**: No SubagentStart/SubagentStop equivalent
+- **Session checkpoints**: Not available
+- **MCP tool events**: Cannot intercept MCP tool calls for validation
+
+## Skills
+
+The bridge gives the agent access to Han's full skill library (400+ skills across 95+ plugins). Two modes:
+
+- **MCP tool**: Agent calls `han_skills` to list/load skills on demand
+- **Native sync**: `han_sync` copies skills to `.agent/skills/` for Antigravity's native semantic matching
+
+## Disciplines
+
+25 agent personas available via `han_discipline`:
+
+- frontend, backend, api, architecture, mobile, database, security
+- infrastructure, sre, performance, accessibility, quality, documentation
+- and more
+
+When activated, the discipline's context is returned with each `han_context` call.
+
+## Event Logging
+
+Events are logged to `~/.han/antigravity/projects/{slug}/{sessionId}-han.jsonl` with `provider: "antigravity"`. The Han coordinator indexes these files and serves them through the Browse UI alongside Claude Code and OpenCode sessions.
+
+## Development
+
+```bash
+# From the han repo root
+cd plugins/bridges/antigravity
+
+# Run the MCP server directly
+bun src/index.ts --project-dir /path/to/project
+
+# The server reads JSON-RPC from stdin and writes to stdout
+```
+
+## License
+
+Apache-2.0

--- a/plugins/bridges/antigravity/han-plugin.yml
+++ b/plugins/bridges/antigravity/han-plugin.yml
@@ -1,0 +1,18 @@
+# Han plugin configuration for the Antigravity bridge.
+#
+# This plugin has no hooks of its own - it IS the bridge that enables
+# other Han plugins' hooks to run inside Google Antigravity IDE via MCP.
+#
+# Installation:
+#   1. Install Han plugins as usual: han plugin install --auto
+#   2. Add MCP server to ~/.gemini/antigravity/mcp_config.json:
+#      { "mcpServers": { "han": { "command": "npx", "args": ["-y", "antigravity-han-mcp"] } } }
+#   3. Han skills, disciplines, and validation are now available in Antigravity.
+
+hooks: {}
+
+learn_patterns:
+  - "antigravity"
+  - "anti.?gravity"
+  - "gemini"
+  - "agy"

--- a/plugins/bridges/antigravity/package.json
+++ b/plugins/bridges/antigravity/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "antigravity-han-mcp",
+  "version": "0.1.0",
+  "description": "Han bridge for Google Antigravity - MCP server enabling Han's validation hooks, skills, and disciplines in Antigravity IDE",
+  "main": "src/index.ts",
+  "bin": "src/index.ts",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src/"
+  ],
+  "keywords": [
+    "antigravity",
+    "google-antigravity",
+    "mcp",
+    "mcp-server",
+    "han",
+    "claude-code",
+    "hooks",
+    "validation",
+    "linting",
+    "bridge",
+    "skills"
+  ],
+  "author": {
+    "name": "The Bushido Collective",
+    "url": "https://thebushido.co"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thebushidocollective/han",
+    "directory": "plugins/bridges/antigravity"
+  },
+  "homepage": "https://github.com/thebushidocollective/han/tree/main/plugins/bridges/antigravity",
+  "engines": {
+    "bun": ">=1.0.0",
+    "node": ">=18.0.0"
+  }
+}

--- a/plugins/bridges/antigravity/src/cache.ts
+++ b/plugins/bridges/antigravity/src/cache.ts
@@ -1,0 +1,86 @@
+/**
+ * Content-hash cache for hook execution.
+ *
+ * Tracks file content hashes per hook. If a file's hash hasn't changed
+ * since the last successful run of a hook, that hook is skipped.
+ *
+ * Cache key: `${pluginName}:${hookName}:${filePath}`
+ * Cache value: content hash after last successful hook run
+ */
+
+import { readFileSync } from "node:fs"
+import { createHash } from "node:crypto"
+
+/** Map of cache keys to content hashes from the last successful run */
+const hashCache = new Map<string, string>()
+
+/**
+ * Compute SHA-256 hash of a file's contents.
+ */
+function hashFile(filePath: string): string | null {
+  try {
+    const content = readFileSync(filePath)
+    return createHash("sha256").update(content).digest("hex")
+  } catch {
+    return null
+  }
+}
+
+function cacheKey(
+  pluginName: string,
+  hookName: string,
+  filePath: string,
+): string {
+  return `${pluginName}:${hookName}:${filePath}`
+}
+
+/**
+ * Check if a hook can be skipped for the given file.
+ */
+export function shouldSkipHook(
+  pluginName: string,
+  hookName: string,
+  filePath: string,
+): boolean {
+  const key = cacheKey(pluginName, hookName, filePath)
+  const cachedHash = hashCache.get(key)
+  if (!cachedHash) return false
+
+  const currentHash = hashFile(filePath)
+  if (!currentHash) return false
+
+  return cachedHash === currentHash
+}
+
+/**
+ * Record a successful hook run.
+ */
+export function recordSuccess(
+  pluginName: string,
+  hookName: string,
+  filePath: string,
+): void {
+  const hash = hashFile(filePath)
+  if (hash) {
+    const key = cacheKey(pluginName, hookName, filePath)
+    hashCache.set(key, hash)
+  }
+}
+
+/**
+ * Invalidate cache for a file across all hooks.
+ */
+export function invalidateFile(filePath: string): void {
+  for (const [key] of hashCache) {
+    if (key.endsWith(`:${filePath}`)) {
+      hashCache.delete(key)
+    }
+  }
+}
+
+/**
+ * Clear the entire cache.
+ */
+export function clearCache(): void {
+  hashCache.clear()
+}

--- a/plugins/bridges/antigravity/src/cache.ts
+++ b/plugins/bridges/antigravity/src/cache.ts
@@ -10,6 +10,7 @@
 
 import { readFileSync } from "node:fs"
 import { createHash } from "node:crypto"
+import { resolve } from "node:path"
 
 /** Map of cache keys to content hashes from the last successful run */
 const hashCache = new Map<string, string>()
@@ -31,7 +32,7 @@ function cacheKey(
   hookName: string,
   filePath: string,
 ): string {
-  return `${pluginName}:${hookName}:${filePath}`
+  return `${pluginName}:${hookName}:${resolve(filePath)}`
 }
 
 /**
@@ -71,8 +72,9 @@ export function recordSuccess(
  * Invalidate cache for a file across all hooks.
  */
 export function invalidateFile(filePath: string): void {
+  const resolved = resolve(filePath)
   for (const [key] of hashCache) {
-    if (key.endsWith(`:${filePath}`)) {
+    if (key.endsWith(`:${resolved}`)) {
       hashCache.delete(key)
     }
   }

--- a/plugins/bridges/antigravity/src/context.ts
+++ b/plugins/bridges/antigravity/src/context.ts
@@ -1,0 +1,92 @@
+/**
+ * Context and guidelines for Antigravity sessions.
+ *
+ * Generates rules content that can be synced to .agent/rules/ or
+ * returned via MCP tools. These guidelines are LLM-universal and
+ * improve agent quality regardless of provider.
+ */
+
+/**
+ * Core guidelines injected into the agent's context.
+ * These are written to .agent/rules/han-guidelines.md by the sync tool.
+ */
+export const CORE_GUIDELINES = `# Han Guidelines
+
+## Professional Honesty - Epistemic Rigor
+
+When a user makes claims about code behavior, bugs, system state, performance, or architecture:
+- **VERIFY BEFORE PROCEEDING** - Read code, search codebase, run tests
+- **NEVER** say "You're absolutely right" or accept claims without evidence
+- **ALWAYS** start with "Let me verify..." or "I'll check the current implementation..."
+- Evidence required: Read files, search with tools, run commands
+
+When user knowledge IS trusted (no verification needed):
+- User preferences, project decisions, new feature requirements, styling choices
+
+## No Time Estimates
+
+- NEVER provide time estimates (hours, days, weeks, months)
+- NEVER use temporal planning language ("Week 1-2", "By month 2")
+- INSTEAD use: Phase numbers, priority order, dependency-based sequencing
+
+## No Excuses Policy
+
+- If you encounter issues, fix them - pre-existing or not
+- NEVER categorize failures as "pre-existing" or "not caused by our changes"
+- You own every issue you see (Boy Scout Rule)
+- Test failures are not acceptable - investigate and fix all of them
+
+## Date Handling
+
+- Use the current date for temporal assertions
+- NEVER hardcode future dates in tests (use relative dates or mock clocks)
+- Use ISO 8601 format for machine-readable timestamps
+- Store dates in UTC, convert to local only for display
+
+## Skill Selection
+
+Review available skills BEFORE starting work. Use han_skills to:
+1. Search for relevant skills matching your task
+2. Load skill content for specialized guidance
+3. Announce which skills you're applying and why
+`
+
+/**
+ * Build rules file content for .agent/rules/han-guidelines.md.
+ */
+export function buildRulesContent(
+  skillCount: number,
+  disciplineCount: number,
+): string {
+  const lines: string[] = [CORE_GUIDELINES]
+
+  lines.push(`## Han Capabilities\n`)
+  lines.push(
+    `Han bridge active with ${skillCount} skills and ${disciplineCount} disciplines available.`,
+  )
+  lines.push(
+    `MCP tools: han_skills (browse/load skills), han_discipline (activate agent personas), han_validate (run validation hooks), han_sync (sync skills/rules)`,
+  )
+  lines.push("")
+
+  return lines.join("\n")
+}
+
+/**
+ * Build per-prompt context with current datetime.
+ */
+export function buildPromptContext(): string {
+  const now = new Date()
+  const dateStr = now.toLocaleString("en-US", {
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  })
+
+  return `Current local time: ${dateStr}`
+}

--- a/plugins/bridges/antigravity/src/disciplines.ts
+++ b/plugins/bridges/antigravity/src/disciplines.ts
@@ -1,0 +1,136 @@
+/**
+ * Discipline discovery and context building for Antigravity.
+ *
+ * Han's discipline plugins define specialized agent personas (frontend,
+ * backend, SRE, security, etc.) with curated skill sets. This module
+ * discovers available disciplines and builds context for injection into
+ * Antigravity's rules or GEMINI.md.
+ */
+
+import { readFileSync, existsSync } from "node:fs"
+import { join } from "node:path"
+import type { SkillInfo } from "./skills"
+
+/**
+ * Discipline metadata parsed from a discipline plugin.
+ */
+export interface DisciplineInfo {
+  /** Discipline name (e.g. "frontend", "sre", "security") */
+  name: string
+  /** Description from plugin.json */
+  description: string
+  /** Plugin root directory */
+  pluginRoot: string
+  /** Skills provided by this discipline */
+  skills: SkillInfo[]
+}
+
+/**
+ * Parse plugin.json for discipline metadata.
+ */
+function parsePluginJson(
+  pluginRoot: string,
+): { name: string; description: string } | null {
+  const pluginJsonPath = join(pluginRoot, ".claude-plugin", "plugin.json")
+  if (!existsSync(pluginJsonPath)) return null
+
+  try {
+    const content = readFileSync(pluginJsonPath, "utf-8")
+    const json = JSON.parse(content)
+    return {
+      name: json.name ?? "",
+      description: json.description ?? "",
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Check if a plugin is a discipline plugin by its directory structure.
+ */
+function isDisciplinePlugin(pluginRoot: string): boolean {
+  return pluginRoot.includes("/disciplines/") || pluginRoot.includes("\\disciplines\\")
+}
+
+/**
+ * Discover all discipline plugins from resolved plugin paths.
+ */
+export function discoverDisciplines(
+  resolvedPlugins: Map<string, string>,
+  allSkills: SkillInfo[],
+): DisciplineInfo[] {
+  const disciplines: DisciplineInfo[] = []
+
+  for (const [pluginName, pluginRoot] of resolvedPlugins) {
+    if (!isDisciplinePlugin(pluginRoot)) continue
+
+    const meta = parsePluginJson(pluginRoot)
+    if (!meta) continue
+
+    const disciplineSkills = allSkills.filter(
+      (s) => s.pluginName === pluginName,
+    )
+
+    disciplines.push({
+      name: pluginName,
+      description: meta.description,
+      pluginRoot,
+      skills: disciplineSkills,
+    })
+  }
+
+  return disciplines
+}
+
+/**
+ * Format discipline list for display.
+ */
+export function formatDisciplineList(disciplines: DisciplineInfo[]): string {
+  if (disciplines.length === 0) {
+    return "No discipline plugins discovered. Install with: han plugin install --auto"
+  }
+
+  const lines: string[] = [`Available disciplines (${disciplines.length}):\n`]
+
+  for (const d of disciplines) {
+    const skillCount = d.skills.length
+    lines.push(
+      `- **${d.name}**: ${d.description || "(no description)"}` +
+        (skillCount > 0 ? ` (${skillCount} skills)` : ""),
+    )
+  }
+
+  lines.push(
+    `\nUse han_discipline with action="activate" and discipline="<name>" to activate a discipline.`,
+  )
+
+  return lines.join("\n")
+}
+
+/**
+ * Build context for an active discipline.
+ * Injected via .agent/rules/ or returned as tool output.
+ */
+export function buildDisciplineContext(discipline: DisciplineInfo): string {
+  const lines: string[] = [
+    `<han-discipline name="${discipline.name}">`,
+    `You are operating as a **${discipline.name}** specialist.`,
+    discipline.description ? `\n${discipline.description}` : "",
+  ]
+
+  if (discipline.skills.length > 0) {
+    lines.push("\n## Available Skills\n")
+    lines.push(
+      "The following specialized skills are available for this discipline. " +
+        "Use han_skills to load any skill's full content when needed:\n",
+    )
+    for (const skill of discipline.skills) {
+      lines.push(`- **${skill.name}**: ${skill.description || "(no description)"}`)
+    }
+  }
+
+  lines.push("</han-discipline>")
+
+  return lines.join("\n")
+}

--- a/plugins/bridges/antigravity/src/discovery.ts
+++ b/plugins/bridges/antigravity/src/discovery.ts
@@ -1,0 +1,355 @@
+/**
+ * Plugin and hook discovery.
+ *
+ * Reads Claude Code settings files to find installed Han plugins,
+ * resolves their paths via the marketplace, and parses han-plugin.yml
+ * to extract hook definitions.
+ *
+ * Shared logic with the OpenCode bridge - reads the same settings
+ * and marketplace files since Han plugins are provider-agnostic.
+ */
+
+import { readFileSync, existsSync } from "node:fs"
+import { join, resolve, dirname } from "node:path"
+import { homedir } from "node:os"
+import type { HookDefinition } from "./types"
+
+// ─── Settings Discovery ─────────────────────────────────────────────────────
+
+interface PluginEntry {
+  enabled?: boolean
+}
+
+interface ClaudeSettings {
+  plugins?: Record<string, PluginEntry>
+}
+
+interface MarketplacePlugin {
+  name: string
+  source: string
+}
+
+interface Marketplace {
+  plugins: MarketplacePlugin[]
+}
+
+/**
+ * Find all enabled Han plugins by merging user, project, and local settings.
+ */
+function getEnabledPlugins(projectDir: string): string[] {
+  const pluginNames = new Set<string>()
+
+  const settingsPaths = [
+    join(homedir(), ".claude", "settings.json"), // user scope
+    join(projectDir, ".claude", "settings.json"), // project scope
+    join(projectDir, ".claude", "settings.local.json"), // local scope
+  ]
+
+  for (const path of settingsPaths) {
+    if (!existsSync(path)) continue
+    try {
+      const content = readFileSync(path, "utf-8")
+      const settings: ClaudeSettings = JSON.parse(content)
+      if (!settings.plugins) continue
+
+      for (const [name, entry] of Object.entries(settings.plugins)) {
+        if (entry.enabled !== false) {
+          // Strip @han suffix if present: "biome@han" -> "biome"
+          const cleanName = name.replace(/@han$/, "")
+          pluginNames.add(cleanName)
+        }
+      }
+    } catch {
+      // Skip unreadable settings files
+    }
+  }
+
+  return Array.from(pluginNames)
+}
+
+// ─── Marketplace Resolution ──────────────────────────────────────────────────
+
+/**
+ * Find the marketplace.json file. Searches up from projectDir to find
+ * the han repository root, or falls back to the npm-installed marketplace.
+ */
+function findMarketplace(projectDir: string): Marketplace | null {
+  const candidates = [
+    join(projectDir, ".claude-plugin", "marketplace.json"),
+    join(homedir(), ".claude", "marketplace.json"),
+  ]
+
+  // Walk up directories looking for .claude-plugin/marketplace.json
+  let dir = projectDir
+  for (let i = 0; i < 10; i++) {
+    const candidate = join(dir, ".claude-plugin", "marketplace.json")
+    if (existsSync(candidate) && !candidates.includes(candidate)) {
+      candidates.unshift(candidate)
+    }
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+
+  for (const path of candidates) {
+    if (!existsSync(path)) continue
+    try {
+      const content = readFileSync(path, "utf-8")
+      return JSON.parse(content) as Marketplace
+    } catch {
+      continue
+    }
+  }
+
+  return null
+}
+
+/**
+ * Resolve a plugin name to its filesystem path using the marketplace.
+ */
+function resolvePluginPath(
+  pluginName: string,
+  marketplace: Marketplace,
+  marketplaceDir: string,
+): string | null {
+  const entry = marketplace.plugins.find((p) => p.name === pluginName)
+  if (!entry) return null
+
+  const pluginPath = resolve(marketplaceDir, entry.source)
+  return existsSync(pluginPath) ? pluginPath : null
+}
+
+// ─── han-plugin.yml Parsing ──────────────────────────────────────────────────
+
+interface RawHookDef {
+  event?: string | string[]
+  command?: string
+  tool_filter?: string[]
+  file_filter?: string[]
+  dirs_with?: string[]
+  dir_test?: string
+  timeout?: number
+}
+
+interface RawPluginConfig {
+  hooks?: Record<string, RawHookDef>
+}
+
+/**
+ * Minimal YAML parser for han-plugin.yml.
+ * Handles the subset of YAML used by Han plugin configs.
+ */
+function parseSimpleYaml(content: string): RawPluginConfig {
+  const result: RawPluginConfig = { hooks: {} }
+  const lines = content.split("\n")
+
+  let currentSection: string | null = null
+  let currentHook: string | null = null
+  let currentField: string | null = null
+
+  for (const line of lines) {
+    const trimmed = line.trimEnd()
+
+    // Top-level section
+    if (/^hooks:\s*$/.test(trimmed)) {
+      currentSection = "hooks"
+      continue
+    }
+
+    if (currentSection !== "hooks") continue
+
+    // Hook name (2-space indent)
+    const hookMatch = trimmed.match(/^  (\S+):\s*$/)
+    if (hookMatch) {
+      currentHook = hookMatch[1]
+      result.hooks![currentHook] = {}
+      currentField = null
+      continue
+    }
+
+    if (!currentHook) continue
+    const hook = result.hooks![currentHook]
+
+    // Simple key-value (4-space indent)
+    const kvMatch = trimmed.match(/^    (\S+):\s*(.+)$/)
+    if (kvMatch) {
+      const [, key, value] = kvMatch
+      const cleanValue = value.replace(/^["']|["']$/g, "")
+      currentField = null
+
+      if (key === "event") {
+        if (cleanValue.startsWith("[")) {
+          hook.event = cleanValue
+            .replace(/^\[|\]$/g, "")
+            .split(",")
+            .map((s) => s.trim())
+        } else {
+          hook.event = cleanValue
+        }
+      } else if (key === "command") {
+        hook.command = cleanValue
+      } else if (key === "dir_test") {
+        hook.dir_test = cleanValue
+      } else if (key === "timeout") {
+        hook.timeout = parseInt(cleanValue, 10)
+      } else if (
+        key === "tool_filter" ||
+        key === "file_filter" ||
+        key === "dirs_with"
+      ) {
+        if (cleanValue.startsWith("[")) {
+          ;(hook as any)[key] = cleanValue
+            .replace(/^\[|\]$/g, "")
+            .split(",")
+            .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+        } else {
+          currentField = key
+        }
+      }
+      continue
+    }
+
+    // Array item (6-space indent with -)
+    const arrayMatch = trimmed.match(/^      - (.+)$/)
+    if (arrayMatch && currentField) {
+      const value = arrayMatch[1].replace(/^["']|["']$/g, "")
+      if (!(hook as any)[currentField]) {
+        ;(hook as any)[currentField] = []
+      }
+      ;(hook as any)[currentField].push(value)
+      continue
+    }
+
+    // Key with no value starts an array
+    const arrayKeyMatch = trimmed.match(/^    (\S+):\s*$/)
+    if (arrayKeyMatch) {
+      currentField = arrayKeyMatch[1]
+      continue
+    }
+  }
+
+  return result
+}
+
+/**
+ * Read and parse a plugin's han-plugin.yml, extracting hook definitions.
+ */
+function parsePluginHooks(
+  pluginName: string,
+  pluginRoot: string,
+): HookDefinition[] {
+  const ymlPath = join(pluginRoot, "han-plugin.yml")
+  if (!existsSync(ymlPath)) return []
+
+  try {
+    const content = readFileSync(ymlPath, "utf-8")
+    const config = parseSimpleYaml(content)
+    if (!config.hooks) return []
+
+    const hooks: HookDefinition[] = []
+
+    for (const [name, def] of Object.entries(config.hooks)) {
+      if (!def.command) continue
+
+      hooks.push({
+        name,
+        pluginName,
+        pluginRoot,
+        event: def.event ?? "Stop",
+        command: def.command,
+        toolFilter: def.tool_filter,
+        fileFilter: def.file_filter,
+        dirsWith: def.dirs_with,
+        dirTest: def.dir_test,
+        timeout: def.timeout,
+      })
+    }
+
+    return hooks
+  } catch {
+    return []
+  }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Resolve enabled plugins to their filesystem paths.
+ * Returns a map of plugin name -> absolute plugin root path.
+ */
+export function resolvePluginPaths(projectDir: string): Map<string, string> {
+  const resolved = new Map<string, string>()
+  const enabledPlugins = getEnabledPlugins(projectDir)
+  if (enabledPlugins.length === 0) return resolved
+
+  const marketplace = findMarketplace(projectDir)
+  if (!marketplace) return resolved
+
+  const marketplaceDir = findMarketplaceDir(projectDir)
+  if (!marketplaceDir) return resolved
+
+  for (const pluginName of enabledPlugins) {
+    const pluginPath = resolvePluginPath(pluginName, marketplace, marketplaceDir)
+    if (pluginPath) {
+      resolved.set(pluginName, pluginPath)
+    }
+  }
+
+  return resolved
+}
+
+/**
+ * Find the directory containing marketplace.json.
+ */
+function findMarketplaceDir(projectDir: string): string | null {
+  const candidates = [
+    join(projectDir, ".claude-plugin"),
+    join(homedir(), ".claude"),
+  ]
+
+  let dir = projectDir
+  for (let i = 0; i < 10; i++) {
+    const candidate = join(dir, ".claude-plugin")
+    if (
+      existsSync(join(candidate, "marketplace.json")) &&
+      !candidates.includes(candidate)
+    ) {
+      candidates.unshift(candidate)
+    }
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+
+  return candidates.find((d) => existsSync(join(d, "marketplace.json"))) ?? null
+}
+
+/**
+ * Discover all hook definitions from installed Han plugins.
+ */
+export function discoverHooks(projectDir: string): HookDefinition[] {
+  const resolved = resolvePluginPaths(projectDir)
+  if (resolved.size === 0) return []
+
+  const allHooks: HookDefinition[] = []
+
+  for (const [pluginName, pluginPath] of resolved) {
+    const hooks = parsePluginHooks(pluginName, pluginPath)
+    allHooks.push(...hooks)
+  }
+
+  return allHooks
+}
+
+/**
+ * Filter hooks to only those matching a specific event type.
+ */
+export function getHooksByEvent(
+  hooks: HookDefinition[],
+  event: string,
+): HookDefinition[] {
+  return hooks.filter((h) => {
+    if (Array.isArray(h.event)) return h.event.includes(event)
+    return h.event === event
+  })
+}

--- a/plugins/bridges/antigravity/src/events.ts
+++ b/plugins/bridges/antigravity/src/events.ts
@@ -1,0 +1,194 @@
+/**
+ * Event logger for the Antigravity bridge.
+ *
+ * Writes Han-format JSONL events with provider="antigravity" so the
+ * coordinator can index them alongside Claude Code and OpenCode sessions.
+ *
+ * Path: ~/.han/antigravity/{project-slug}/{sessionId}-han.jsonl
+ */
+
+import { randomUUID } from "node:crypto"
+import { appendFileSync, mkdirSync } from "node:fs"
+import { dirname, join } from "node:path"
+import type { HookDefinition, HookResult, HanProvider } from "./types"
+
+const MAX_OUTPUT_LENGTH = 10_000
+
+/**
+ * Convert a filesystem path to a slug.
+ */
+function pathToSlug(fsPath: string): string {
+  return fsPath.replace(/^\//, "-").replace(/[/.]/g, "-")
+}
+
+/**
+ * Get the han data root for Antigravity.
+ */
+function getHanAntigravityRoot(): string {
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? "/tmp"
+  return join(home, ".han", "antigravity")
+}
+
+/**
+ * Get the JSONL events file path for an Antigravity session.
+ */
+function getEventsFilePath(projectDir: string, sessionId: string): string {
+  const slug = pathToSlug(projectDir)
+  return join(getHanAntigravityRoot(), "projects", slug, `${sessionId}-han.jsonl`)
+}
+
+interface BaseEventMeta {
+  uuid: string
+  sessionId: string
+  type: string
+  timestamp: string
+  provider: HanProvider
+  cwd?: string
+}
+
+function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_LENGTH) return output
+  return `${output.slice(0, MAX_OUTPUT_LENGTH)}\n... [truncated, ${output.length - MAX_OUTPUT_LENGTH} more bytes]`
+}
+
+/**
+ * Event logger for Antigravity bridge sessions.
+ */
+export class BridgeEventLogger {
+  private logPath: string
+  private buffer: string[] = []
+  private flushTimer: ReturnType<typeof setTimeout> | null = null
+  private readonly sessionId: string
+  private readonly provider: HanProvider = "antigravity"
+  private readonly cwd: string
+
+  constructor(sessionId: string, projectDir: string) {
+    this.sessionId = sessionId
+    this.cwd = projectDir
+    this.logPath = getEventsFilePath(projectDir, sessionId)
+
+    try {
+      mkdirSync(dirname(this.logPath), { recursive: true })
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw err
+      }
+    }
+
+    console.error(
+      `[han] Event logger initialized: ${this.logPath}`,
+    )
+  }
+
+  private createBase(type: string): BaseEventMeta {
+    return {
+      uuid: randomUUID(),
+      sessionId: this.sessionId,
+      type,
+      timestamp: new Date().toISOString(),
+      provider: this.provider,
+      cwd: this.cwd,
+    }
+  }
+
+  private writeEvent(event: Record<string, unknown>): void {
+    const line = `${JSON.stringify(event)}\n`
+    this.buffer.push(line)
+
+    const type = event.type as string
+    if (type.endsWith("_result")) {
+      this.flush()
+    } else {
+      this.scheduleFlush()
+    }
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return
+    this.flushTimer = setTimeout(() => {
+      this.flush()
+    }, 100)
+  }
+
+  flush(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer)
+      this.flushTimer = null
+    }
+    if (this.buffer.length === 0) return
+
+    try {
+      appendFileSync(this.logPath, this.buffer.join(""))
+      this.buffer = []
+    } catch (err) {
+      console.error(
+        `[han] Failed to write events:`,
+        err instanceof Error ? err.message : err,
+      )
+    }
+  }
+
+  /**
+   * Log hook_run event. Returns UUID for correlating with hook_result.
+   */
+  logHookRun(hook: HookDefinition, hookType: string): string {
+    const base = this.createBase("hook_run")
+    this.writeEvent({
+      ...base,
+      data: {
+        plugin: hook.pluginName,
+        hook: hook.name,
+        hook_type: hookType,
+        directory: this.cwd,
+        cached: false,
+        command: hook.command,
+      },
+    })
+    return base.uuid
+  }
+
+  /**
+   * Log hook_result event.
+   */
+  logHookResult(result: HookResult, hookType: string, hookRunId: string): void {
+    this.writeEvent({
+      ...this.createBase("hook_result"),
+      hookRunId,
+      data: {
+        plugin: result.hook.pluginName,
+        hook: result.hook.name,
+        hook_type: hookType,
+        directory: this.cwd,
+        cached: result.skipped,
+        duration_ms: result.durationMs,
+        exit_code: result.exitCode,
+        success: result.exitCode === 0,
+        output: result.stdout ? truncateOutput(result.stdout) : undefined,
+        error: result.stderr || undefined,
+        command: result.hook.command,
+      },
+    })
+  }
+
+  /**
+   * Log hook_file_change event.
+   */
+  logFileChange(toolName: string, filePath: string): void {
+    this.writeEvent({
+      ...this.createBase("hook_file_change"),
+      data: {
+        session_id: this.sessionId,
+        tool_name: toolName,
+        file_path: filePath,
+      },
+    })
+  }
+
+  getLogPath(): string {
+    return this.logPath
+  }
+
+  getWatchDir(): string {
+    return join(getHanAntigravityRoot(), "projects")
+  }
+}

--- a/plugins/bridges/antigravity/src/executor.ts
+++ b/plugins/bridges/antigravity/src/executor.ts
@@ -1,0 +1,184 @@
+/**
+ * Promise-based hook executor.
+ *
+ * Runs hook commands as child processes, capturing stdout/stderr/exit code.
+ * Results are collected and returned for formatting into MCP tool responses.
+ */
+
+import { spawn } from "node:child_process"
+import type { HookDefinition, HookResult } from "./types"
+import { shouldSkipHook, recordSuccess } from "./cache"
+import type { BridgeEventLogger } from "./events"
+
+const DEFAULT_TIMEOUT = 60_000
+
+/**
+ * Execute a single hook command as a promise.
+ */
+export function executeHook(
+  hook: HookDefinition,
+  filePaths: string[],
+  options: {
+    cwd: string
+    sessionId: string
+    timeout?: number
+    eventLogger?: BridgeEventLogger
+    hookType?: string
+  },
+): Promise<HookResult> {
+  const startTime = Date.now()
+
+  // Check cache
+  if (filePaths.length > 0) {
+    const allCached = filePaths.every((fp) =>
+      shouldSkipHook(hook.pluginName, hook.name, fp),
+    )
+    if (allCached) {
+      return Promise.resolve({
+        hook,
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        durationMs: 0,
+        skipped: true,
+      })
+    }
+  }
+
+  // Substitute variables
+  const filesArg = filePaths.join(" ")
+  let command = hook.command.replace(/\$\{HAN_FILES\}/g, filesArg)
+  command = command.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, hook.pluginRoot)
+
+  if (hook.command.includes("${HAN_FILES}") && filePaths.length === 0) {
+    return Promise.resolve({
+      hook,
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      durationMs: 0,
+      skipped: true,
+    })
+  }
+
+  // Log hook_run event
+  const hookRunId = options.eventLogger?.logHookRun(
+    hook,
+    options.hookType ?? "Stop",
+  )
+
+  return new Promise((resolve) => {
+    const timeout = hook.timeout ?? options.timeout ?? DEFAULT_TIMEOUT
+
+    const child = spawn(command, {
+      cwd: options.cwd,
+      shell: "/bin/bash",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        CLAUDE_PLUGIN_ROOT: hook.pluginRoot,
+        CLAUDE_PROJECT_DIR: options.cwd,
+        HAN_SESSION_ID: options.sessionId,
+        HAN_PROVIDER: "antigravity",
+        HAN_FILES: filesArg,
+        HAN_FILE: filePaths[0] ?? "",
+      },
+      timeout,
+    })
+
+    let stdout = ""
+    let stderr = ""
+
+    child.stdout.on("data", (data: Buffer) => {
+      stdout += data.toString()
+    })
+
+    child.stderr.on("data", (data: Buffer) => {
+      stderr += data.toString()
+    })
+
+    child.on("close", (code) => {
+      const exitCode = code ?? 1
+
+      if (exitCode === 0) {
+        for (const fp of filePaths) {
+          recordSuccess(hook.pluginName, hook.name, fp)
+        }
+      }
+
+      const result: HookResult = {
+        hook,
+        exitCode,
+        stdout,
+        stderr,
+        durationMs: Date.now() - startTime,
+        skipped: false,
+      }
+
+      if (options.eventLogger && hookRunId) {
+        options.eventLogger.logHookResult(
+          result,
+          options.hookType ?? "Stop",
+          hookRunId,
+        )
+      }
+
+      resolve(result)
+    })
+
+    child.on("error", (err) => {
+      const result: HookResult = {
+        hook,
+        exitCode: 127,
+        stdout: "",
+        stderr: `Failed to execute: ${err.message}`,
+        durationMs: Date.now() - startTime,
+        skipped: false,
+      }
+
+      if (options.eventLogger && hookRunId) {
+        options.eventLogger.logHookResult(
+          result,
+          options.hookType ?? "Stop",
+          hookRunId,
+        )
+      }
+
+      resolve(result)
+    })
+  })
+}
+
+/**
+ * Execute multiple hooks in parallel and collect all results.
+ */
+export async function executeHooksParallel(
+  hooks: HookDefinition[],
+  filePaths: string[],
+  options: {
+    cwd: string
+    sessionId: string
+    timeout?: number
+    eventLogger?: BridgeEventLogger
+    hookType?: string
+  },
+): Promise<HookResult[]> {
+  if (hooks.length === 0) return []
+
+  const results = await Promise.allSettled(
+    hooks.map((hook) => executeHook(hook, filePaths, options)),
+  )
+
+  return results.map((r) =>
+    r.status === "fulfilled"
+      ? r.value
+      : {
+          hook: hooks[0],
+          exitCode: 1,
+          stdout: "",
+          stderr: r.reason?.message ?? "Unknown error",
+          durationMs: 0,
+          skipped: false,
+        },
+  )
+}

--- a/plugins/bridges/antigravity/src/executor.ts
+++ b/plugins/bridges/antigravity/src/executor.ts
@@ -169,11 +169,11 @@ export async function executeHooksParallel(
     hooks.map((hook) => executeHook(hook, filePaths, options)),
   )
 
-  return results.map((r) =>
+  return results.map((r, i) =>
     r.status === "fulfilled"
       ? r.value
       : {
-          hook: hooks[0],
+          hook: hooks[i],
           exitCode: 1,
           stdout: "",
           stderr: r.reason?.message ?? "Unknown error",

--- a/plugins/bridges/antigravity/src/formatter.ts
+++ b/plugins/bridges/antigravity/src/formatter.ts
@@ -1,0 +1,104 @@
+/**
+ * Result formatting: turns raw hook results into structured messages
+ * for MCP tool responses.
+ *
+ * Uses XML-like tags for clear structure, matching the OpenCode bridge's
+ * format so results are consistent across providers.
+ */
+
+import type { HookResult } from "./types"
+
+/**
+ * Format a single hook result as a structured validation block.
+ */
+function formatSingleResult(result: HookResult): string {
+  const { hook, exitCode, stdout, stderr } = result
+  const status = exitCode === 0 ? "passed" : "failed"
+  const output = (stdout || stderr).trim()
+
+  if (!output) return ""
+
+  return [
+    `<han-validation plugin="${hook.pluginName}" hook="${hook.name}" status="${status}">`,
+    output,
+    `</han-validation>`,
+  ].join("\n")
+}
+
+/**
+ * Format validation results for MCP tool response.
+ *
+ * Returns all results (passed and failed) with clear status indicators
+ * since MCP tools return complete responses.
+ */
+export function formatValidationResults(
+  results: HookResult[],
+  filePaths?: string[],
+): string {
+  const failures = results.filter((r) => !r.skipped && r.exitCode !== 0)
+  const successes = results.filter((r) => !r.skipped && r.exitCode === 0)
+  const skipped = results.filter((r) => r.skipped)
+
+  if (failures.length === 0 && successes.length === 0 && skipped.length === 0) {
+    return "No validation hooks matched. Ensure Han plugins are installed: han plugin install --auto"
+  }
+
+  const lines: string[] = []
+
+  if (filePaths && filePaths.length > 0) {
+    lines.push(`Files: ${filePaths.join(", ")}\n`)
+  }
+
+  if (failures.length > 0) {
+    lines.push(
+      `**${failures.length} validation issue${failures.length > 1 ? "s" : ""} found:**\n`,
+    )
+    for (const result of failures) {
+      const block = formatSingleResult(result)
+      if (block) lines.push(block)
+    }
+  }
+
+  if (successes.length > 0) {
+    lines.push(
+      `\n**${successes.length} check${successes.length > 1 ? "s" : ""} passed:**`,
+    )
+    for (const result of successes) {
+      lines.push(`- ${result.hook.pluginName}/${result.hook.name} (${result.durationMs}ms)`)
+    }
+  }
+
+  if (skipped.length > 0) {
+    lines.push(`\n*${skipped.length} hook${skipped.length > 1 ? "s" : ""} skipped (cached/no matching files)*`)
+  }
+
+  if (failures.length === 0) {
+    lines.push("\nAll validation checks passed.")
+  } else {
+    lines.push("\nPlease fix the issues above before continuing.")
+  }
+
+  return lines.join("\n")
+}
+
+/**
+ * Format Stop hook results (project-wide validation).
+ */
+export function formatStopResults(results: HookResult[]): string | null {
+  const failures = results.filter(
+    (r) => !r.skipped && r.exitCode !== 0,
+  )
+
+  if (failures.length === 0) return null
+
+  const blocks = failures.map(formatSingleResult).filter(Boolean)
+  if (blocks.length === 0) return null
+
+  return [
+    "<han-validation-summary>",
+    "Han validation hooks found issues that need to be fixed:",
+    "",
+    ...blocks,
+    "</han-validation-summary>",
+  ].join("\n")
+}

--- a/plugins/bridges/antigravity/src/index.ts
+++ b/plugins/bridges/antigravity/src/index.ts
@@ -33,12 +33,13 @@
  * via rules to call han_validate after edits.
  */
 
+import { spawn } from "node:child_process"
 import { discoverHooks, resolvePluginPaths, getHooksByEvent } from "./discovery"
 import { matchPostToolUseHooks, matchStopHooks } from "./matcher"
 import { executeHooksParallel } from "./executor"
 import { invalidateFile } from "./cache"
 import { formatValidationResults } from "./formatter"
-import { mapToolName } from "./types"
+import { mapToolName, type HookDefinition } from "./types"
 import { BridgeEventLogger } from "./events"
 import {
   discoverAllSkills,
@@ -61,30 +62,28 @@ const PREFIX = "[han]"
  * Start the Han coordinator daemon in the background.
  */
 function startCoordinator(watchDir: string): void {
-  try {
-    const { spawn } = require("node:child_process") as typeof import("node:child_process")
-
-    const child = spawn(
-      "han",
-      ["coordinator", "ensure", "--background", "--watch-path", watchDir],
-      {
-        stdio: "ignore",
-        detached: true,
-        env: {
-          ...process.env,
-          HAN_PROVIDER: "antigravity",
-        },
+  const child = spawn(
+    "han",
+    ["coordinator", "ensure", "--background", "--watch-path", watchDir],
+    {
+      stdio: "ignore",
+      detached: true,
+      env: {
+        ...process.env,
+        HAN_PROVIDER: "antigravity",
       },
-    )
+    },
+  )
 
-    child.unref()
-    console.error(`${PREFIX} Coordinator ensure started (watch: ${watchDir})`)
-  } catch {
+  child.on("error", () => {
     console.error(
       `${PREFIX} Could not start coordinator (han CLI not found). ` +
         `Browse UI won't show Antigravity sessions.`,
     )
-  }
+  })
+
+  child.unref()
+  console.error(`${PREFIX} Coordinator ensure started (watch: ${watchDir})`)
 }
 
 /**
@@ -140,8 +139,6 @@ export async function createHanMcpServer(projectDir: string) {
 
   // ─── Session State ───────────────────────────────────────────────────────
   const sessionId = crypto.randomUUID()
-  process.env.HAN_PROVIDER = "antigravity"
-  process.env.HAN_SESSION_ID = sessionId
 
   // ─── Event Logger ──────────────────────────────────────────────────────
   const eventLogger = new BridgeEventLogger(sessionId, projectDir)
@@ -153,6 +150,7 @@ export async function createHanMcpServer(projectDir: string) {
   return {
     name: "han",
     version: "0.1.0",
+    eventLogger,
     tools: {
       /**
        * han_skills - Browse and load Han's skill library.
@@ -340,15 +338,28 @@ export async function createHanMcpServer(projectDir: string) {
               invalidateFile(fp)
             }
 
-            // Find and run matching PostToolUse hooks for the first file
-            const matching = matchPostToolUseHooks(
-              postToolUseHooks,
-              claudeToolName,
-              args.files[0],
-              projectDir,
-            )
+            // Match hooks per-file, then group files by their matched hook
+            // so mixed-extension file sets (e.g. .ts + .py) each run only
+            // the hooks that actually apply to them.
+            const hookToFiles = new Map<HookDefinition, string[]>()
+            for (const file of args.files) {
+              const matched = matchPostToolUseHooks(
+                postToolUseHooks,
+                claudeToolName,
+                file,
+                projectDir,
+              )
+              for (const hook of matched) {
+                const files = hookToFiles.get(hook)
+                if (files) {
+                  files.push(file)
+                } else {
+                  hookToFiles.set(hook, [file])
+                }
+              }
+            }
 
-            if (matching.length === 0) {
+            if (hookToFiles.size === 0) {
               return {
                 content: [{
                   type: "text" as const,
@@ -358,12 +369,18 @@ export async function createHanMcpServer(projectDir: string) {
               }
             }
 
-            const results = await executeHooksParallel(matching, args.files, {
-              cwd: projectDir,
-              sessionId,
-              eventLogger,
-              hookType: "PostToolUse",
-            })
+            const results = (
+              await Promise.all(
+                Array.from(hookToFiles.entries()).map(([hook, files]) =>
+                  executeHooksParallel([hook], files, {
+                    cwd: projectDir,
+                    sessionId,
+                    eventLogger,
+                    hookType: "PostToolUse",
+                  }),
+                ),
+              )
+            ).flat()
 
             return {
               content: [{
@@ -483,7 +500,7 @@ export async function createHanMcpServer(projectDir: string) {
  *   "mcpServers": {
  *     "han": {
  *       "command": "npx",
- *       "args": ["-y", "@thebushidocollective/antigravity-han-mcp"]
+ *       "args": ["-y", "antigravity-han-mcp"]
  *     }
  *   }
  * }
@@ -497,6 +514,7 @@ async function main() {
   console.error(`${PREFIX} Project: ${projectDir}`)
 
   const server = await createHanMcpServer(projectDir)
+  const eventLogger = server.eventLogger
 
   // MCP stdio transport: read JSON-RPC from stdin, write to stdout
   const { createInterface } = await import("node:readline")
@@ -596,12 +614,17 @@ async function main() {
 
   rl.on("close", () => {
     console.error(`${PREFIX} MCP server shutting down`)
+    eventLogger.flush()
     process.exit(0)
   })
 }
 
-// Run if invoked directly
-if (require.main === module || process.argv[1]?.endsWith("index.ts")) {
+// Run if invoked directly (ESM has no require.main; compare against the
+// invoked script path instead, with a Bun-specific fallback for dev runs).
+if (
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("index.ts")
+) {
   main().catch((err) => {
     console.error(`${PREFIX} Fatal error:`, err)
     process.exit(1)

--- a/plugins/bridges/antigravity/src/index.ts
+++ b/plugins/bridges/antigravity/src/index.ts
@@ -1,0 +1,611 @@
+/**
+ * Han Bridge for Antigravity (Google)
+ *
+ * MCP server that brings Han's plugin ecosystem to Antigravity IDE.
+ *
+ * Architecture:
+ *
+ *   Antigravity doesn't have lifecycle hooks like Claude Code or OpenCode.
+ *   Instead, the bridge integrates via MCP server, exposing Han's
+ *   capabilities as tools the agent can call:
+ *
+ *   han_skills (MCP tool)
+ *     -> skills.ts discovers SKILL.md from installed plugins
+ *     -> Agent can list and load 400+ skills on demand
+ *
+ *   han_discipline (MCP tool)
+ *     -> disciplines.ts discovers agent personas
+ *     -> Agent activates/deactivates specialized disciplines
+ *
+ *   han_validate (MCP tool)
+ *     -> executor.ts runs matching validation hooks
+ *     -> Returns structured results for the agent to act on
+ *     -> Supports file-specific (PostToolUse) and project-wide (Stop) validation
+ *
+ *   han_sync (MCP tool)
+ *     -> sync.ts copies skills to .agent/skills/ for native discovery
+ *     -> sync.ts generates .agent/rules/han-guidelines.md
+ *     -> Antigravity discovers Han skills without MCP calls
+ *
+ * Key difference from OpenCode bridge: Antigravity lacks event hooks,
+ * so validation is on-demand (agent calls han_validate) rather than
+ * automatic (triggered by tool.execute.after). The agent is instructed
+ * via rules to call han_validate after edits.
+ */
+
+import { discoverHooks, resolvePluginPaths, getHooksByEvent } from "./discovery"
+import { matchPostToolUseHooks, matchStopHooks } from "./matcher"
+import { executeHooksParallel } from "./executor"
+import { invalidateFile } from "./cache"
+import { formatValidationResults } from "./formatter"
+import { mapToolName } from "./types"
+import { BridgeEventLogger } from "./events"
+import {
+  discoverAllSkills,
+  loadSkillContent,
+  formatSkillList,
+  type SkillInfo,
+} from "./skills"
+import {
+  discoverDisciplines,
+  formatDisciplineList,
+  buildDisciplineContext,
+  type DisciplineInfo,
+} from "./disciplines"
+import { buildPromptContext } from "./context"
+import { syncAll } from "./sync"
+
+const PREFIX = "[han]"
+
+/**
+ * Start the Han coordinator daemon in the background.
+ */
+function startCoordinator(watchDir: string): void {
+  try {
+    const { spawn } = require("node:child_process") as typeof import("node:child_process")
+
+    const child = spawn(
+      "han",
+      ["coordinator", "ensure", "--background", "--watch-path", watchDir],
+      {
+        stdio: "ignore",
+        detached: true,
+        env: {
+          ...process.env,
+          HAN_PROVIDER: "antigravity",
+        },
+      },
+    )
+
+    child.unref()
+    console.error(`${PREFIX} Coordinator ensure started (watch: ${watchDir})`)
+  } catch {
+    console.error(
+      `${PREFIX} Could not start coordinator (han CLI not found). ` +
+        `Browse UI won't show Antigravity sessions.`,
+    )
+  }
+}
+
+/**
+ * Create and start the Han MCP server for Antigravity.
+ *
+ * This is the main entry point. It discovers plugins, sets up tools,
+ * and returns an MCP server configuration that Antigravity can use.
+ */
+export async function createHanMcpServer(projectDir: string) {
+  // ─── Plugin Discovery ───────────────────────────────────────────────────
+  const resolvedPlugins = resolvePluginPaths(projectDir)
+
+  // ─── Hook Discovery ──────────────────────────────────────────────────────
+  const allHooks = discoverHooks(projectDir)
+  const postToolUseHooks = getHooksByEvent(allHooks, "PostToolUse")
+  const stopHooks = getHooksByEvent(allHooks, "Stop")
+
+  // ─── Skill Discovery ──────────────────────────────────────────────────────
+  const allSkills = discoverAllSkills(resolvedPlugins)
+  const skillsByName = new Map<string, SkillInfo>()
+  for (const skill of allSkills) {
+    skillsByName.set(skill.name, skill)
+  }
+
+  // ─── Discipline Discovery ──────────────────────────────────────────────────
+  const allDisciplines = discoverDisciplines(resolvedPlugins, allSkills)
+  const disciplinesByName = new Map<string, DisciplineInfo>()
+  for (const d of allDisciplines) {
+    disciplinesByName.set(d.name, d)
+  }
+
+  let activeDiscipline: DisciplineInfo | null = null
+
+  // ─── Logging ──────────────────────────────────────────────────────────────
+  const pluginCount = resolvedPlugins.size
+  const skillCount = allSkills.length
+  const disciplineCount = allDisciplines.length
+
+  if (pluginCount === 0) {
+    console.error(
+      `${PREFIX} No Han plugins found. ` +
+        `Install plugins: han plugin install --auto`,
+    )
+  } else {
+    console.error(
+      `${PREFIX} Discovered ${pluginCount} plugins: ` +
+        `${postToolUseHooks.length} PostToolUse, ` +
+        `${stopHooks.length} Stop hooks, ` +
+        `${skillCount} skills, ` +
+        `${disciplineCount} disciplines`,
+    )
+  }
+
+  // ─── Session State ───────────────────────────────────────────────────────
+  const sessionId = crypto.randomUUID()
+  process.env.HAN_PROVIDER = "antigravity"
+  process.env.HAN_SESSION_ID = sessionId
+
+  // ─── Event Logger ──────────────────────────────────────────────────────
+  const eventLogger = new BridgeEventLogger(sessionId, projectDir)
+
+  // ─── Coordinator ───────────────────────────────────────────────────────
+  startCoordinator(eventLogger.getWatchDir())
+
+  // ─── MCP Tool Definitions ─────────────────────────────────────────────
+  return {
+    name: "han",
+    version: "0.1.0",
+    tools: {
+      /**
+       * han_skills - Browse and load Han's skill library.
+       */
+      han_skills: {
+        description:
+          "Browse and load Han skills (400+ specialized coding skills). " +
+          'Use action="list" to search available skills, ' +
+          'action="load" with skill name to get full skill content.',
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            action: {
+              type: "string" as const,
+              enum: ["list", "load"],
+              description: 'Action: "list" to search, "load" to get content',
+            },
+            skill: {
+              type: "string" as const,
+              description: "Skill name to load (required for action=load)",
+            },
+            filter: {
+              type: "string" as const,
+              description: "Search filter (optional for action=list)",
+            },
+          },
+          required: ["action"],
+        },
+        async execute(args: { action: string; skill?: string; filter?: string }) {
+          if (args.action === "load") {
+            if (!args.skill) {
+              return { content: [{ type: "text" as const, text: "Error: skill parameter required for action=load" }] }
+            }
+
+            const skill = skillsByName.get(args.skill)
+            if (!skill) {
+              const matches = allSkills.filter((s) =>
+                s.name.toLowerCase().includes(args.skill!.toLowerCase()),
+              )
+              if (matches.length === 1) {
+                return { content: [{ type: "text" as const, text: loadSkillContent(matches[0]) }] }
+              }
+              if (matches.length > 1) {
+                return {
+                  content: [{
+                    type: "text" as const,
+                    text:
+                      `Multiple skills match "${args.skill}":\n` +
+                      matches.map((s) => `- ${s.name}`).join("\n") +
+                      "\n\nBe more specific.",
+                  }],
+                }
+              }
+              return { content: [{ type: "text" as const, text: `Skill "${args.skill}" not found. Use action="list" to see available skills.` }] }
+            }
+
+            return { content: [{ type: "text" as const, text: loadSkillContent(skill) }] }
+          }
+
+          return { content: [{ type: "text" as const, text: formatSkillList(allSkills, args.filter) }] }
+        },
+      },
+
+      /**
+       * han_discipline - Activate specialized agent disciplines.
+       */
+      han_discipline: {
+        description:
+          "Activate a Han discipline (specialized agent persona). " +
+          'Use action="list" to see available disciplines, ' +
+          'action="activate" to switch, action="deactivate" to clear.',
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            action: {
+              type: "string" as const,
+              enum: ["list", "activate", "deactivate"],
+              description: 'Action: "list", "activate", or "deactivate"',
+            },
+            discipline: {
+              type: "string" as const,
+              description: "Discipline name (required for activate)",
+            },
+          },
+          required: ["action"],
+        },
+        async execute(args: { action: string; discipline?: string }) {
+          if (args.action === "activate") {
+            if (!args.discipline) {
+              return { content: [{ type: "text" as const, text: "Error: discipline parameter required for activate" }] }
+            }
+
+            const d = disciplinesByName.get(args.discipline)
+            if (!d) {
+              return {
+                content: [{
+                  type: "text" as const,
+                  text:
+                    `Discipline "${args.discipline}" not found.\n\n` +
+                    formatDisciplineList(allDisciplines),
+                }],
+              }
+            }
+
+            activeDiscipline = d
+            return {
+              content: [{
+                type: "text" as const,
+                text:
+                  `Activated discipline: **${d.name}**\n\n` +
+                  `${d.description}\n\n` +
+                  (d.skills.length > 0
+                    ? `${d.skills.length} specialized skills available. ` +
+                      `Use han_skills to load any of them.\n\n` +
+                      buildDisciplineContext(d)
+                    : ""),
+              }],
+            }
+          }
+
+          if (args.action === "deactivate") {
+            const prev = activeDiscipline?.name
+            activeDiscipline = null
+            return {
+              content: [{
+                type: "text" as const,
+                text: prev
+                  ? `Deactivated discipline: ${prev}`
+                  : "No discipline was active.",
+              }],
+            }
+          }
+
+          return { content: [{ type: "text" as const, text: formatDisciplineList(allDisciplines) }] }
+        },
+      },
+
+      /**
+       * han_validate - Run validation hooks on demand.
+       *
+       * Since Antigravity lacks lifecycle hooks, the agent calls this
+       * tool explicitly after making edits or before finishing a task.
+       *
+       * Two modes:
+       *   - file: Run PostToolUse hooks for specific files (after edits)
+       *   - project: Run Stop hooks for full project validation (before finishing)
+       */
+      han_validate: {
+        description:
+          "Run Han validation hooks (linting, type checking, formatting). " +
+          'Use mode="file" with file paths after editing files, or ' +
+          'mode="project" for full project validation before completing a task.',
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            mode: {
+              type: "string" as const,
+              enum: ["file", "project"],
+              description: '"file" for per-file validation, "project" for full project check',
+            },
+            files: {
+              type: "array" as const,
+              items: { type: "string" as const },
+              description: "File paths to validate (required for mode=file)",
+            },
+            tool: {
+              type: "string" as const,
+              description: 'Tool that edited the files (e.g. "Edit", "Write"). Defaults to "Edit".',
+            },
+          },
+          required: ["mode"],
+        },
+        async execute(args: { mode: string; files?: string[]; tool?: string }) {
+          if (args.mode === "file") {
+            if (!args.files || args.files.length === 0) {
+              return { content: [{ type: "text" as const, text: "Error: files parameter required for mode=file" }] }
+            }
+
+            const claudeToolName = args.tool
+              ? mapToolName(args.tool)
+              : "Edit"
+
+            // Invalidate cache for edited files
+            for (const fp of args.files) {
+              invalidateFile(fp)
+            }
+
+            // Find and run matching PostToolUse hooks for the first file
+            const matching = matchPostToolUseHooks(
+              postToolUseHooks,
+              claudeToolName,
+              args.files[0],
+              projectDir,
+            )
+
+            if (matching.length === 0) {
+              return {
+                content: [{
+                  type: "text" as const,
+                  text: `No validation hooks matched for ${args.files.join(", ")}. ` +
+                    `(${postToolUseHooks.length} PostToolUse hooks registered)`,
+                }],
+              }
+            }
+
+            const results = await executeHooksParallel(matching, args.files, {
+              cwd: projectDir,
+              sessionId,
+              eventLogger,
+              hookType: "PostToolUse",
+            })
+
+            return {
+              content: [{
+                type: "text" as const,
+                text: formatValidationResults(results, args.files),
+              }],
+            }
+          }
+
+          if (args.mode === "project") {
+            const matching = matchStopHooks(stopHooks, projectDir)
+
+            if (matching.length === 0) {
+              return {
+                content: [{
+                  type: "text" as const,
+                  text: `No project validation hooks matched. ` +
+                    `(${stopHooks.length} Stop hooks registered)`,
+                }],
+              }
+            }
+
+            const results = await executeHooksParallel(matching, [], {
+              cwd: projectDir,
+              sessionId,
+              timeout: 120_000,
+              eventLogger,
+              hookType: "Stop",
+            })
+
+            eventLogger.flush()
+
+            return {
+              content: [{
+                type: "text" as const,
+                text: formatValidationResults(results),
+              }],
+            }
+          }
+
+          return {
+            content: [{
+              type: "text" as const,
+              text: 'Error: mode must be "file" or "project"',
+            }],
+            isError: true,
+          }
+        },
+      },
+
+      /**
+       * han_sync - Sync Han assets to Antigravity's native directories.
+       *
+       * Copies skills to .agent/skills/ and generates rules in .agent/rules/
+       * so Antigravity discovers them natively without MCP tool calls.
+       */
+      han_sync: {
+        description:
+          "Sync Han skills and rules to Antigravity's native directories " +
+          "(.agent/skills/ and .agent/rules/). This lets Antigravity discover " +
+          "Han's skills natively. Run once after installing new plugins.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {},
+          required: [],
+        },
+        async execute() {
+          const result = syncAll(projectDir, allSkills, allDisciplines)
+          return { content: [{ type: "text" as const, text: result }] }
+        },
+      },
+
+      /**
+       * han_context - Get current session context.
+       *
+       * Returns current time, active discipline, and capabilities summary.
+       * Useful since Antigravity doesn't have automatic context injection hooks.
+       */
+      han_context: {
+        description:
+          "Get current Han session context including time, active discipline, " +
+          "and capabilities summary.",
+        inputSchema: {
+          type: "object" as const,
+          properties: {},
+          required: [],
+        },
+        async execute() {
+          const lines: string[] = []
+
+          lines.push(buildPromptContext())
+          lines.push("")
+
+          if (activeDiscipline) {
+            lines.push(`Active discipline: **${activeDiscipline.name}**`)
+            lines.push(buildDisciplineContext(activeDiscipline))
+          } else {
+            lines.push("No discipline active. Use han_discipline to activate one.")
+          }
+
+          lines.push("")
+          lines.push(`Available: ${skillCount} skills, ${disciplineCount} disciplines`)
+          lines.push(`Validation: ${postToolUseHooks.length} PostToolUse hooks, ${stopHooks.length} Stop hooks`)
+
+          return { content: [{ type: "text" as const, text: lines.join("\n") }] }
+        },
+      },
+    },
+  }
+}
+
+/**
+ * CLI entry point for running the MCP server via stdio.
+ *
+ * Usage in mcp_config.json:
+ * {
+ *   "mcpServers": {
+ *     "han": {
+ *       "command": "npx",
+ *       "args": ["-y", "@thebushidocollective/antigravity-han-mcp"]
+ *     }
+ *   }
+ * }
+ */
+async function main() {
+  const projectDir = process.argv.includes("--project-dir")
+    ? process.argv[process.argv.indexOf("--project-dir") + 1]
+    : process.cwd()
+
+  console.error(`${PREFIX} Starting Han MCP server for Antigravity`)
+  console.error(`${PREFIX} Project: ${projectDir}`)
+
+  const server = await createHanMcpServer(projectDir)
+
+  // MCP stdio transport: read JSON-RPC from stdin, write to stdout
+  const { createInterface } = await import("node:readline")
+  const rl = createInterface({ input: process.stdin })
+
+  const tools = server.tools
+
+  rl.on("line", async (line) => {
+    try {
+      const request = JSON.parse(line)
+
+      if (request.method === "initialize") {
+        const response = {
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            protocolVersion: "2024-11-05",
+            serverInfo: { name: server.name, version: server.version },
+            capabilities: {
+              tools: {},
+            },
+          },
+        }
+        process.stdout.write(JSON.stringify(response) + "\n")
+        return
+      }
+
+      if (request.method === "tools/list") {
+        const toolList = Object.entries(tools).map(([name, tool]) => ({
+          name,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+        }))
+        const response = {
+          jsonrpc: "2.0",
+          id: request.id,
+          result: { tools: toolList },
+        }
+        process.stdout.write(JSON.stringify(response) + "\n")
+        return
+      }
+
+      if (request.method === "tools/call") {
+        const { name, arguments: args } = request.params
+        const tool = tools[name as keyof typeof tools]
+        if (!tool) {
+          const response = {
+            jsonrpc: "2.0",
+            id: request.id,
+            error: { code: -32601, message: `Unknown tool: ${name}` },
+          }
+          process.stdout.write(JSON.stringify(response) + "\n")
+          return
+        }
+
+        try {
+          const result = await tool.execute(args ?? {})
+          const response = {
+            jsonrpc: "2.0",
+            id: request.id,
+            result,
+          }
+          process.stdout.write(JSON.stringify(response) + "\n")
+        } catch (err) {
+          const response = {
+            jsonrpc: "2.0",
+            id: request.id,
+            result: {
+              content: [{
+                type: "text",
+                text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+              }],
+              isError: true,
+            },
+          }
+          process.stdout.write(JSON.stringify(response) + "\n")
+        }
+        return
+      }
+
+      if (request.method === "notifications/initialized") {
+        // No response needed for notifications
+        return
+      }
+
+      // Unknown method
+      const response = {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: { code: -32601, message: `Method not found: ${request.method}` },
+      }
+      process.stdout.write(JSON.stringify(response) + "\n")
+    } catch (err) {
+      console.error(`${PREFIX} Parse error:`, err)
+    }
+  })
+
+  rl.on("close", () => {
+    console.error(`${PREFIX} MCP server shutting down`)
+    process.exit(0)
+  })
+}
+
+// Run if invoked directly
+if (require.main === module || process.argv[1]?.endsWith("index.ts")) {
+  main().catch((err) => {
+    console.error(`${PREFIX} Fatal error:`, err)
+    process.exit(1)
+  })
+}
+
+export default createHanMcpServer

--- a/plugins/bridges/antigravity/src/matcher.ts
+++ b/plugins/bridges/antigravity/src/matcher.ts
@@ -1,0 +1,99 @@
+/**
+ * Hook matching: determines which hooks should fire for a given context.
+ *
+ * Checks tool name against toolFilter and file path against fileFilter
+ * to find hooks that apply to a specific validation request.
+ */
+
+import { existsSync } from "node:fs"
+import { join, relative } from "node:path"
+import type { HookDefinition } from "./types"
+
+/**
+ * Test if a file path matches a glob-like pattern.
+ */
+function matchGlob(pattern: string, filePath: string): boolean {
+  let regexStr = pattern
+    .replace(/\./g, "\\.")
+    .replace(/\{([^}]+)\}/g, (_match, group: string) => {
+      const alts = group.split(",").map((s: string) => s.trim())
+      return `(${alts.join("|")})`
+    })
+    .replace(/\*\*/g, "<<<GLOBSTAR>>>")
+    .replace(/\*/g, "[^/]*")
+    .replace(/<<<GLOBSTAR>>>/g, ".*")
+
+  regexStr = `^${regexStr}$`
+
+  try {
+    return new RegExp(regexStr).test(filePath)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Check if a hook's dirsWith requirement is met.
+ */
+function checkDirsWith(
+  hook: HookDefinition,
+  projectDir: string,
+): boolean {
+  if (!hook.dirsWith || hook.dirsWith.length === 0) return true
+  return hook.dirsWith.some((requiredFile) =>
+    existsSync(join(projectDir, requiredFile)),
+  )
+}
+
+/**
+ * Check if a file matches the hook's fileFilter patterns.
+ */
+function checkFileFilter(
+  hook: HookDefinition,
+  filePath: string,
+  projectDir: string,
+): boolean {
+  if (!hook.fileFilter || hook.fileFilter.length === 0) return true
+  const relPath = relative(projectDir, filePath)
+  return hook.fileFilter.some(
+    (pattern) => matchGlob(pattern, relPath) || matchGlob(pattern, filePath),
+  )
+}
+
+/**
+ * Check if a tool name matches the hook's toolFilter.
+ */
+function checkToolFilter(
+  hook: HookDefinition,
+  claudeToolName: string,
+): boolean {
+  if (!hook.toolFilter || hook.toolFilter.length === 0) return true
+  return hook.toolFilter.includes(claudeToolName)
+}
+
+/**
+ * Find PostToolUse hooks matching a given tool + file combination.
+ */
+export function matchPostToolUseHooks(
+  hooks: HookDefinition[],
+  claudeToolName: string,
+  filePath: string,
+  projectDir: string,
+): HookDefinition[] {
+  return hooks.filter((hook) => {
+    if (!checkToolFilter(hook, claudeToolName)) return false
+    if (!checkDirsWith(hook, projectDir)) return false
+    if (!checkFileFilter(hook, filePath, projectDir)) return false
+    return true
+  })
+}
+
+/**
+ * Find Stop hooks that apply to the current project.
+ */
+export function matchStopHooks(
+  hooks: HookDefinition[],
+  projectDir: string,
+): HookDefinition[] {
+  return hooks.filter((hook) => checkDirsWith(hook, projectDir))
+}

--- a/plugins/bridges/antigravity/src/matcher.ts
+++ b/plugins/bridges/antigravity/src/matcher.ts
@@ -6,6 +6,7 @@
  */
 
 import { existsSync } from "node:fs"
+import { execSync } from "node:child_process"
 import { join, relative } from "node:path"
 import type { HookDefinition } from "./types"
 
@@ -43,6 +44,24 @@ function checkDirsWith(
   return hook.dirsWith.some((requiredFile) =>
     existsSync(join(projectDir, requiredFile)),
   )
+}
+
+/**
+ * Check if a hook's dirTest command succeeds in the project directory.
+ * Used for conditional execution (e.g. skip if a tool is disabled).
+ */
+function checkDirTest(hook: HookDefinition, projectDir: string): boolean {
+  if (!hook.dirTest) return true
+  try {
+    execSync(hook.dirTest, {
+      cwd: projectDir,
+      stdio: ["ignore", "ignore", "ignore"],
+      shell: "/bin/bash",
+    })
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**
@@ -84,6 +103,7 @@ export function matchPostToolUseHooks(
     if (!checkToolFilter(hook, claudeToolName)) return false
     if (!checkDirsWith(hook, projectDir)) return false
     if (!checkFileFilter(hook, filePath, projectDir)) return false
+    if (!checkDirTest(hook, projectDir)) return false
     return true
   })
 }
@@ -95,5 +115,7 @@ export function matchStopHooks(
   hooks: HookDefinition[],
   projectDir: string,
 ): HookDefinition[] {
-  return hooks.filter((hook) => checkDirsWith(hook, projectDir))
+  return hooks.filter(
+    (hook) => checkDirsWith(hook, projectDir) && checkDirTest(hook, projectDir),
+  )
 }

--- a/plugins/bridges/antigravity/src/skills.ts
+++ b/plugins/bridges/antigravity/src/skills.ts
@@ -1,0 +1,204 @@
+/**
+ * Skill discovery and registration for Antigravity.
+ *
+ * Scans installed Han plugins for skills/ directories containing SKILL.md
+ * files. Exposes via MCP tools so the agent can list and load skills.
+ *
+ * Antigravity has its own skill system (.agent/skills/) using the same
+ * SKILL.md format. The han_sync tool can optionally copy skills there
+ * for native discovery. This module provides on-demand access without
+ * filesystem duplication.
+ */
+
+import { readFileSync, existsSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+
+/**
+ * Parsed skill metadata from SKILL.md frontmatter.
+ */
+export interface SkillInfo {
+  /** Skill name (from frontmatter or directory name) */
+  name: string
+  /** Human-readable description */
+  description: string
+  /** Parent plugin name */
+  pluginName: string
+  /** Allowed tools (empty = all) */
+  allowedTools: string[]
+  /** Full path to SKILL.md */
+  filePath: string
+}
+
+/**
+ * Parse YAML frontmatter from a SKILL.md file.
+ */
+function parseFrontmatter(content: string): {
+  meta: Record<string, unknown>
+  body: string
+} {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+  if (!match) return { meta: {}, body: content }
+
+  const meta: Record<string, unknown> = {}
+  const lines = match[1].split("\n")
+  let currentKey: string | null = null
+
+  for (const line of lines) {
+    const kvMatch = line.match(/^(\S+):\s*(.+)$/)
+    if (kvMatch) {
+      const [, key, value] = kvMatch
+      meta[key] = value.replace(/^["']|["']$/g, "")
+      currentKey = null
+      continue
+    }
+
+    const keyMatch = line.match(/^(\S+):\s*$/)
+    if (keyMatch) {
+      currentKey = keyMatch[1]
+      meta[currentKey] = []
+      continue
+    }
+
+    const inlineArrayMatch = line.match(/^(\S+):\s*\[([^\]]*)\]$/)
+    if (inlineArrayMatch) {
+      const [, key, items] = inlineArrayMatch
+      meta[key] = items
+        .split(",")
+        .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+        .filter(Boolean)
+      currentKey = null
+      continue
+    }
+
+    const arrayMatch = line.match(/^\s*-\s+(.+)$/)
+    if (arrayMatch && currentKey && Array.isArray(meta[currentKey])) {
+      ;(meta[currentKey] as string[]).push(
+        arrayMatch[1].replace(/^["']|["']$/g, ""),
+      )
+    }
+  }
+
+  return { meta, body: match[2] }
+}
+
+/**
+ * Discover all skills from a plugin directory.
+ */
+function discoverPluginSkills(
+  pluginName: string,
+  pluginRoot: string,
+): SkillInfo[] {
+  const skillsDir = join(pluginRoot, "skills")
+  if (!existsSync(skillsDir)) return []
+
+  const skills: SkillInfo[] = []
+
+  try {
+    const entries = readdirSync(skillsDir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+
+      const skillMd = join(skillsDir, entry.name, "SKILL.md")
+      if (!existsSync(skillMd)) continue
+
+      try {
+        const content = readFileSync(skillMd, "utf-8")
+        const { meta } = parseFrontmatter(content)
+
+        skills.push({
+          name: (meta.name as string) || entry.name,
+          description: (meta.description as string) || "",
+          pluginName,
+          allowedTools: Array.isArray(meta["allowed-tools"])
+            ? (meta["allowed-tools"] as string[])
+            : [],
+          filePath: skillMd,
+        })
+      } catch {
+        // Skip unreadable skills
+      }
+    }
+  } catch {
+    // Skills directory not readable
+  }
+
+  return skills
+}
+
+/**
+ * Discover all skills from all resolved plugin paths.
+ */
+export function discoverAllSkills(
+  resolvedPlugins: Map<string, string>,
+): SkillInfo[] {
+  const allSkills: SkillInfo[] = []
+
+  for (const [pluginName, pluginRoot] of resolvedPlugins) {
+    const skills = discoverPluginSkills(pluginName, pluginRoot)
+    allSkills.push(...skills)
+  }
+
+  return allSkills
+}
+
+/**
+ * Load the full content of a skill's SKILL.md.
+ */
+export function loadSkillContent(skill: SkillInfo): string {
+  try {
+    return readFileSync(skill.filePath, "utf-8")
+  } catch {
+    return `Error: Could not read skill file at ${skill.filePath}`
+  }
+}
+
+/**
+ * Format a skill list for display.
+ */
+export function formatSkillList(
+  skills: SkillInfo[],
+  filter?: string,
+): string {
+  let filtered = skills
+
+  if (filter) {
+    const lower = filter.toLowerCase()
+    filtered = skills.filter(
+      (s) =>
+        s.name.toLowerCase().includes(lower) ||
+        s.description.toLowerCase().includes(lower) ||
+        s.pluginName.toLowerCase().includes(lower),
+    )
+  }
+
+  if (filtered.length === 0) {
+    return filter
+      ? `No skills matching "${filter}". Try a broader search term.`
+      : "No Han skills discovered. Install plugins: han plugin install --auto"
+  }
+
+  // Group by plugin
+  const byPlugin = new Map<string, SkillInfo[]>()
+  for (const skill of filtered) {
+    const existing = byPlugin.get(skill.pluginName) || []
+    existing.push(skill)
+    byPlugin.set(skill.pluginName, existing)
+  }
+
+  const lines: string[] = [`Found ${filtered.length} skills:\n`]
+
+  for (const [plugin, pluginSkills] of byPlugin) {
+    lines.push(`## ${plugin}`)
+    for (const skill of pluginSkills) {
+      lines.push(`- **${skill.name}**: ${skill.description || "(no description)"}`)
+    }
+    lines.push("")
+  }
+
+  lines.push(
+    `\nUse han_skills with action="load" and skill="<name>" to load a skill's full content.`,
+  )
+
+  return lines.join("\n")
+}

--- a/plugins/bridges/antigravity/src/sync.ts
+++ b/plugins/bridges/antigravity/src/sync.ts
@@ -1,0 +1,197 @@
+/**
+ * Sync Han assets to Antigravity's native directories.
+ *
+ * Antigravity discovers skills and rules from:
+ *   - .agent/skills/<name>/SKILL.md  (per-project skills)
+ *   - .agent/rules/<name>.md         (per-project rules)
+ *   - ~/.gemini/antigravity/skills/  (global skills)
+ *
+ * This module copies Han's skills and generates rules files so
+ * Antigravity can discover them natively without MCP tool calls.
+ * This is optional - the MCP tools (han_skills, han_discipline)
+ * work without syncing.
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  readdirSync,
+  rmSync,
+} from "node:fs"
+import { join, basename } from "node:path"
+import type { SkillInfo } from "./skills"
+import type { DisciplineInfo } from "./disciplines"
+import { buildRulesContent } from "./context"
+
+const HAN_SYNC_MARKER = "<!-- managed by han bridge - do not edit -->"
+
+/**
+ * Sync skills to .agent/skills/ directory.
+ *
+ * Copies SKILL.md files from installed Han plugins into Antigravity's
+ * workspace skills directory. Antigravity will discover them natively.
+ *
+ * @returns Number of skills synced
+ */
+export function syncSkills(
+  projectDir: string,
+  skills: SkillInfo[],
+): { synced: number; removed: number } {
+  const agentSkillsDir = join(projectDir, ".agent", "skills")
+  mkdirSync(agentSkillsDir, { recursive: true })
+
+  // Track which skill directories we manage
+  const managedSkills = new Set<string>()
+  let synced = 0
+
+  for (const skill of skills) {
+    const skillDir = join(agentSkillsDir, `han-${skill.pluginName}-${skill.name}`)
+    managedSkills.add(basename(skillDir))
+
+    mkdirSync(skillDir, { recursive: true })
+
+    // Read source SKILL.md
+    let content: string
+    try {
+      content = readFileSync(skill.filePath, "utf-8")
+    } catch {
+      continue
+    }
+
+    // Add managed marker to content
+    const markedContent = `${HAN_SYNC_MARKER}\n${content}`
+
+    const targetPath = join(skillDir, "SKILL.md")
+
+    // Only write if content changed
+    if (existsSync(targetPath)) {
+      try {
+        const existing = readFileSync(targetPath, "utf-8")
+        if (existing === markedContent) continue
+      } catch {
+        // Re-write on read error
+      }
+    }
+
+    writeFileSync(targetPath, markedContent)
+    synced++
+  }
+
+  // Remove skills we previously synced but are no longer active
+  let removed = 0
+  try {
+    const entries = readdirSync(agentSkillsDir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      if (!entry.name.startsWith("han-")) continue
+      if (managedSkills.has(entry.name)) continue
+
+      // Check if it has our marker before removing
+      const skillMd = join(agentSkillsDir, entry.name, "SKILL.md")
+      if (existsSync(skillMd)) {
+        try {
+          const content = readFileSync(skillMd, "utf-8")
+          if (content.startsWith(HAN_SYNC_MARKER)) {
+            rmSync(join(agentSkillsDir, entry.name), { recursive: true })
+            removed++
+          }
+        } catch {
+          // Skip if can't read
+        }
+      }
+    }
+  } catch {
+    // Directory might not exist yet
+  }
+
+  return { synced, removed }
+}
+
+/**
+ * Sync Han guidelines to .agent/rules/ directory.
+ *
+ * Generates a rules file with Han's core guidelines so Antigravity
+ * injects them into the agent's context natively.
+ *
+ * @returns Whether the rules file was updated
+ */
+export function syncRules(
+  projectDir: string,
+  skillCount: number,
+  disciplineCount: number,
+): boolean {
+  const rulesDir = join(projectDir, ".agent", "rules")
+  mkdirSync(rulesDir, { recursive: true })
+
+  const rulesPath = join(rulesDir, "han-guidelines.md")
+  const content = `${HAN_SYNC_MARKER}\n${buildRulesContent(skillCount, disciplineCount)}`
+
+  // Only write if changed
+  if (existsSync(rulesPath)) {
+    try {
+      const existing = readFileSync(rulesPath, "utf-8")
+      if (existing === content) return false
+    } catch {
+      // Re-write on read error
+    }
+  }
+
+  writeFileSync(rulesPath, content)
+  return true
+}
+
+/**
+ * Generate MCP config entry for Han in Antigravity's mcp_config.json.
+ *
+ * Returns the JSON config that should be added to
+ * ~/.gemini/antigravity/mcp_config.json.
+ */
+export function generateMcpConfig(projectDir: string): string {
+  const config = {
+    mcpServers: {
+      han: {
+        command: "npx",
+        args: [
+          "-y",
+          "@thebushidocollective/antigravity-han-mcp",
+          "--project-dir",
+          projectDir,
+        ],
+      },
+    },
+  }
+
+  return JSON.stringify(config, null, 2)
+}
+
+/**
+ * Full sync: skills + rules + report.
+ */
+export function syncAll(
+  projectDir: string,
+  skills: SkillInfo[],
+  disciplines: DisciplineInfo[],
+): string {
+  const skillResult = syncSkills(projectDir, skills)
+  const rulesUpdated = syncRules(projectDir, skills.length, disciplines.length)
+
+  const lines: string[] = ["Han sync complete:\n"]
+
+  lines.push(`- Skills: ${skillResult.synced} synced to .agent/skills/`)
+  if (skillResult.removed > 0) {
+    lines.push(`  (${skillResult.removed} stale skills removed)`)
+  }
+
+  lines.push(`- Rules: ${rulesUpdated ? "updated" : "up to date"} at .agent/rules/han-guidelines.md`)
+  lines.push(`\nAntigravity will now discover ${skills.length} skills natively.`)
+
+  if (disciplines.length > 0) {
+    lines.push(
+      `\n${disciplines.length} disciplines available via han_discipline tool.`,
+    )
+  }
+
+  return lines.join("\n")
+}

--- a/plugins/bridges/antigravity/src/sync.ts
+++ b/plugins/bridges/antigravity/src/sync.ts
@@ -153,12 +153,7 @@ export function generateMcpConfig(projectDir: string): string {
     mcpServers: {
       han: {
         command: "npx",
-        args: [
-          "-y",
-          "@thebushidocollective/antigravity-han-mcp",
-          "--project-dir",
-          projectDir,
-        ],
+        args: ["-y", "antigravity-han-mcp", "--project-dir", projectDir],
       },
     },
   }

--- a/plugins/bridges/antigravity/src/types.ts
+++ b/plugins/bridges/antigravity/src/types.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared type definitions for the Han-Antigravity bridge.
+ *
+ * Antigravity (Google's agent-first IDE) doesn't have a lifecycle hooks
+ * system like OpenCode. Instead, the bridge integrates via MCP server,
+ * exposing skills, disciplines, and on-demand validation as tools.
+ *
+ * Configuration:
+ *   - Global: ~/.gemini/antigravity/mcp_config.json
+ *   - Rules: .agent/rules/
+ *   - Skills: .agent/skills/
+ *   - Workflows: .agent/workflows/
+ */
+
+// ─── Antigravity Configuration Types ─────────────────────────────────────────
+
+/**
+ * Antigravity MCP server configuration in mcp_config.json.
+ */
+export interface AntigravityMcpConfig {
+  mcpServers: Record<
+    string,
+    {
+      command: string
+      args?: string[]
+      env?: Record<string, string>
+    }
+  >
+}
+
+/**
+ * Antigravity settings from .gemini/settings.json.
+ */
+export interface AntigravitySettings {
+  "tools.autoAccept"?: string[]
+  [key: string]: unknown
+}
+
+// ─── MCP Tool Types ──────────────────────────────────────────────────────────
+
+/**
+ * MCP tool definition shape for the bridge's tools.
+ */
+export interface McpToolDefinition {
+  name: string
+  description: string
+  inputSchema: {
+    type: "object"
+    properties: Record<string, McpToolProperty>
+    required?: string[]
+  }
+}
+
+export interface McpToolProperty {
+  type: string
+  description: string
+  enum?: string[]
+}
+
+/**
+ * MCP tool call result.
+ */
+export interface McpToolResult {
+  content: Array<{
+    type: "text"
+    text: string
+  }>
+  isError?: boolean
+}
+
+// ─── Han Hook Types ──────────────────────────────────────────────────────────
+
+/**
+ * A hook definition parsed from a plugin's han-plugin.yml.
+ */
+export interface HookDefinition {
+  /** Hook name (key in the hooks map, e.g. "lint-async") */
+  name: string
+  /** Plugin short name (e.g. "biome") */
+  pluginName: string
+  /** Absolute path to the plugin directory */
+  pluginRoot: string
+  /** The hook event type(s) */
+  event: string | string[]
+  /** Shell command to execute (may contain ${HAN_FILES}) */
+  command: string
+  /** Which tools trigger this hook (e.g. ["Edit", "Write", "NotebookEdit"]) */
+  toolFilter?: string[]
+  /** File glob patterns that trigger this hook */
+  fileFilter?: string[]
+  /** Directories required to exist (e.g. ["biome.json"]) */
+  dirsWith?: string[]
+  /** Bash expression to test if hook applies to this directory */
+  dirTest?: string
+  /** Timeout in milliseconds */
+  timeout?: number
+}
+
+/**
+ * Result of executing a single hook command.
+ */
+export interface HookResult {
+  /** The hook that was executed */
+  hook: HookDefinition
+  /** Process exit code (0 = success) */
+  exitCode: number
+  /** Combined stdout output */
+  stdout: string
+  /** Combined stderr output */
+  stderr: string
+  /** Execution duration in milliseconds */
+  durationMs: number
+  /** Whether the hook was skipped (e.g. no matching files) */
+  skipped: boolean
+}
+
+// ─── Provider ────────────────────────────────────────────────────────────────
+
+/**
+ * Han provider identifies which AI coding tool is running the session.
+ */
+export type HanProvider = "antigravity" | "opencode" | "claude-code"
+
+export function getProvider(): HanProvider {
+  const env = process.env.HAN_PROVIDER
+  if (env === "antigravity") return "antigravity"
+  if (env === "opencode") return "opencode"
+  return "claude-code"
+}
+
+// ─── Antigravity -> Claude Code Tool Name Mapping ────────────────────────────
+
+/**
+ * Map Antigravity tool names to Claude Code tool names.
+ * Antigravity uses similar naming to VS Code extensions and Gemini tools.
+ */
+export const TOOL_NAME_MAP: Record<string, string> = {
+  edit_file: "Edit",
+  write_file: "Write",
+  read_file: "Read",
+  run_terminal_command: "Bash",
+  search_files: "Grep",
+  list_files: "Glob",
+  edit: "Edit",
+  write: "Write",
+  bash: "Bash",
+  read: "Read",
+  glob: "Glob",
+  grep: "Grep",
+}
+
+export function mapToolName(antigravityTool: string): string {
+  return TOOL_NAME_MAP[antigravityTool.toLowerCase()] ?? antigravityTool
+}

--- a/website/content/docs/_nav.json
+++ b/website/content/docs/_nav.json
@@ -18,6 +18,10 @@
 				{
 					"title": "Using Han with Gemini CLI",
 					"slug": "installation/gemini-cli"
+				},
+				{
+					"title": "Using Han with Antigravity",
+					"slug": "installation/antigravity"
 				}
 			]
 		},

--- a/website/content/docs/installation/antigravity.md
+++ b/website/content/docs/installation/antigravity.md
@@ -1,0 +1,179 @@
+---
+title: "Using Han with Google Antigravity"
+description: "How to use Han's validation pipeline, skills, and disciplines with Google Antigravity IDE via MCP server."
+---
+
+Han works with [Google Antigravity](https://antigravity.google/) through an MCP server bridge that exposes Han's skills, disciplines, and validation hooks as tools the agent can call.
+
+## How It Works
+
+Antigravity doesn't have lifecycle hooks like Claude Code or OpenCode. Instead, Han integrates via MCP server, exposing capabilities as tools:
+
+1. **MCP tools** → **Skills, disciplines, validation** (agent calls on demand)
+2. **Native sync** → **`.agent/skills/` and `.agent/rules/`** (Antigravity discovers natively)
+3. **Event logging** → **Browse UI** (sessions visible alongside Claude Code sessions)
+
+```text
+Agent finishes editing src/app.ts
+  -> Agent calls han_validate({ mode: "file", files: ["src/app.ts"] })
+  -> Bridge matches PostToolUse hooks (biome, eslint, tsc)
+  -> Runs hooks in parallel, returns structured results
+  -> Agent fixes validation errors
+```
+
+## Setup
+
+### 1. Install Han and plugins
+
+```bash
+curl -fsSL https://han.guru/install.sh | bash
+han plugin install --auto
+```
+
+### 2. Add the MCP server to Antigravity
+
+Add to `~/.gemini/antigravity/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "han": {
+      "command": "npx",
+      "args": ["-y", "antigravity-han-mcp"]
+    }
+  }
+}
+```
+
+### 3. Optional: Sync skills natively
+
+Ask the agent to run `han_sync` to copy skills to `.agent/skills/` and generate `.agent/rules/han-guidelines.md`. This lets Antigravity discover Han's skills via its native semantic matching without MCP tool calls.
+
+## Available Tools
+
+The bridge exposes five MCP tools:
+
+| Tool | Purpose | Usage |
+|------|---------|-------|
+| `han_skills` | Browse/load 400+ coding skills | `han_skills({ action: "list", filter: "react" })` |
+| `han_discipline` | Activate agent personas (25 disciplines) | `han_discipline({ action: "activate", discipline: "frontend" })` |
+| `han_validate` | Run validation hooks on demand | `han_validate({ mode: "file", files: ["src/app.ts"] })` |
+| `han_sync` | Sync skills/rules to `.agent/` directory | `han_sync({})` |
+| `han_context` | Get time, active discipline, stats | `han_context({})` |
+
+## Validation
+
+Since Antigravity doesn't have automatic tool lifecycle hooks, validation is on-demand. The agent calls `han_validate` after edits or before finishing.
+
+### Per-File Validation (After Edits)
+
+```text
+han_validate({ mode: "file", files: ["src/app.ts"], tool: "Edit" })
+```
+
+Runs matching PostToolUse hooks:
+
+| Plugin | What It Does |
+|--------|-------------|
+| `biome` | Lint and format JavaScript/TypeScript |
+| `eslint` | JavaScript/TypeScript linting |
+| `prettier` | Code formatting |
+| `typescript` | Type checking |
+| `clippy` | Rust linting |
+| `pylint` | Python linting |
+
+### Project-Wide Validation (Before Finishing)
+
+```text
+han_validate({ mode: "project" })
+```
+
+Runs all Stop hooks for comprehensive project validation:
+
+- Full project linting
+- Type checking across the codebase
+- Test suite execution
+
+## Skills (400+)
+
+The `han_skills` tool gives the agent access to Han's full skill library without duplicating files:
+
+```text
+han_skills({ action: "list", filter: "typescript" })
+-> Lists all TypeScript-related skills
+
+han_skills({ action: "load", skill: "typescript-type-system" })
+-> Loads full skill content into context
+```
+
+Alternatively, run `han_sync` to copy skills to `.agent/skills/` for native Antigravity discovery via semantic matching.
+
+## Disciplines (25 Agent Personas)
+
+Activate specialized agent expertise via `han_discipline`:
+
+```text
+han_discipline({ action: "list" })
+-> Available: frontend, backend, sre, security, mobile, database...
+
+han_discipline({ action: "activate", discipline: "frontend" })
+-> Agent now operates with frontend specialist context
+```
+
+Available disciplines: frontend, backend, api, architecture, mobile, database, security, infrastructure, sre, performance, accessibility, quality, documentation, project-management, product, data-engineering, machine-learning, and more.
+
+## Native Integration via Sync
+
+Running `han_sync` copies Han's assets to Antigravity's native directories:
+
+- **Skills** → `.agent/skills/han-*/SKILL.md` (native semantic discovery)
+- **Rules** → `.agent/rules/han-guidelines.md` (auto-injected guidelines)
+
+This means Antigravity discovers Han's skills via its built-in semantic matching system, without needing to call MCP tools. The rules file provides core guidelines (professional honesty, no time estimates, skill selection) that are injected into every agent context.
+
+## Comparison with Claude Code and OpenCode
+
+| Feature | Claude Code | OpenCode | Antigravity |
+|---------|-------------|----------|-------------|
+| Integration type | Native hooks | JS plugin API | MCP server |
+| Validation trigger | Automatic (PostToolUse) | Automatic (tool.execute.after) | On-demand (han_validate) |
+| Context injection | SessionStart hook | system.transform | .agent/rules/ + han_context |
+| Skill access | han_skills tool | han_skills tool | han_skills + .agent/skills/ sync |
+| Discipline support | do-* plugins | han_discipline tool | han_discipline tool |
+
+## Remaining Gaps
+
+These are platform limitations in Antigravity (as of Feb 2026):
+
+- **Automatic validation**: No lifecycle hooks, so validation requires explicit `han_validate` calls. You can add a rule in `.agent/rules/` instructing the agent to validate after edits.
+- **Permission denial**: Cannot block tool execution (no PreToolUse equivalent).
+- **Subagent hooks**: No SubagentStart/SubagentStop equivalent.
+- **MCP tool events**: Cannot intercept MCP tool calls for validation.
+- **Session checkpoints**: Not available.
+
+## How Plugins Stay Compatible
+
+Han plugins don't need modification to work with Antigravity. The bridge reads the same `han-plugin.yml` files that Claude Code and OpenCode use:
+
+```yaml
+# This config works in Claude Code, OpenCode, AND Antigravity
+hooks:
+  lint-async:
+    event: PostToolUse
+    command: "npx -y @biomejs/biome check --write ${HAN_FILES}"
+    tool_filter: [Edit, Write, NotebookEdit]
+    file_filter: ["**/*.{js,jsx,ts,tsx}"]
+    dirs_with: ["biome.json"]
+```
+
+Same hook definition. Same validation. Different runtime.
+
+## Event Logging
+
+The bridge writes JSONL events to `~/.han/antigravity/projects/`. Each event includes `provider: "antigravity"`. The Han coordinator indexes these and serves them through the Browse UI alongside Claude Code and OpenCode sessions.
+
+## Next Steps
+
+- [Install Han plugins](/docs/installation/plugins) for your project's languages and tools
+- Read about [hook configuration](/docs/plugin-development/hooks) to understand what hooks do
+- Check the [bridge source code](https://github.com/TheBushidoCollective/han/tree/main/plugins/bridges/antigravity) for implementation details

--- a/website/content/docs/installation/index.md
+++ b/website/content/docs/installation/index.md
@@ -76,6 +76,12 @@ Han works with [OpenCode](https://opencode.ai) through a bridge plugin that tran
 
 Your Han validation hooks (biome, eslint, typescript, etc.) now run in OpenCode. See the [full OpenCode guide](/docs/installation/opencode) for details.
 
+## Antigravity
+
+Han works with [Google Antigravity IDE](https://antigravity.google) through a bridge plugin that exposes Han's plugin ecosystem (skills, disciplines, validation) as MCP tools. Antigravity lacks lifecycle hooks like Claude Code/OpenCode, so capabilities are surfaced as callable MCP tools instead.
+
+See the [full Antigravity guide](/docs/installation/antigravity) for setup.
+
 ## Next Steps
 
 After installing Han, you'll want to:


### PR DESCRIPTION
## Summary

Brings Han's plugin ecosystem (skills, disciplines, validation hooks) to [Google Antigravity IDE](https://antigravity.google). Antigravity lacks lifecycle hooks like Claude Code / OpenCode, so the bridge exposes Han capabilities as callable MCP tools instead.

**MCP tools:**

- `han_skills` — list/load 400+ coding skills from installed plugins
- `han_discipline` — activate/deactivate specialized agent personas
- `han_validate` — run validation hooks on-demand (file or project)
- `han_sync` — sync skills/rules to `.agent/` for native discovery
- `han_context` — current session context (time, active discipline, stats)

Implementation mirrors the existing OpenCode bridge (`discovery.ts`, `matcher.ts`, `executor.ts`, `formatter.ts`, `cache.ts`, `events.ts`).

## Wiring

- `.claude-plugin/marketplace.json` — `Integration` category entry alongside the other bridges
- `packages/han/lib/plugin-aliases.ts` — `hashi-antigravity` legacy alias
- `website/content/docs/_nav.json` — installation sidebar entry
- `website/content/docs/installation/index.md` — short callout linking to the full antigravity install page
- `website/content/docs/installation/antigravity.md` — full setup + tool reference (carried over from #76)

## Relation to #76

#76 was 307 commits behind main and 4 ahead, with conflicts in `marketplace.json` and `plugin-aliases.ts` whose shape on main has moved substantially. Rather than blind-rebase, this PR carries the bridge source verbatim from that branch and redoes the surrounding wiring against current main shapes. #76 can be closed once this lands.

## Test plan

- [ ] `claude plugin validate plugins/bridges/antigravity` (or the equivalent claudelint check) passes — covered by the `claudelint` workflow.
- [ ] Validate that `marketplace.json` still parses and the new `antigravity` entry resolves to `./plugins/bridges/antigravity`.
- [ ] Manual: configure the MCP server in Antigravity per `docs/installation/antigravity.md` and verify `han_skills` lists installed plugin skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)