### PR TITLE
Kotlin coroutines skill: added Quarkus and new volatile-related boundary

### DIFF
--- a/plugins/languages/kotlin/skills/kotlin-coroutines/SKILL.md
+++ b/plugins/languages/kotlin/skills/kotlin-coroutines/SKILL.md
@@ -712,6 +712,9 @@ functions. Exception handling respects structured concurrency boundaries.
 10. **Test coroutines with TestCoroutineDispatcher** to control time and ensure
     deterministic test execution
 
+11. **Avoid using volatile for synchronization of coroutines** running on multi-threaded dispatchers.
+    This can cause shared mutable state problems. Prefer Atomic types or synchronization structures like Mutex.withLock.
+
 ## Common Pitfalls
 
 1. **Using GlobalScope for scoped work** causes memory leaks when coroutines
@@ -743,6 +746,7 @@ functions. Exception handling respects structured concurrency boundaries.
 
 10. **Mixing callbacks and coroutines incorrectly** without proper bridging
     creates race conditions and leaks
+    
 
 ## When to Use This Skill
 
@@ -750,7 +754,7 @@ Use Kotlin coroutines when building Android applications for asynchronous
 operations like network calls, database queries, or any I/O-bound work that
 should not block the main thread.
 
-Apply coroutines in server-side Kotlin applications with Ktor or Spring Boot for
+Apply coroutines in server-side Kotlin applications with Ktor, Spring Boot or Quarkus for
 handling concurrent requests efficiently without thread-per-request overhead.
 
 Employ Flow for reactive streams in MVVM architecture, replacing LiveData or

--- a/plugins/languages/kotlin/skills/kotlin-coroutines/SKILL.md
+++ b/plugins/languages/kotlin/skills/kotlin-coroutines/SKILL.md
@@ -746,7 +746,6 @@ functions. Exception handling respects structured concurrency boundaries.
 
 10. **Mixing callbacks and coroutines incorrectly** without proper bridging
     creates race conditions and leaks
-    
 
 ## When to Use This Skill
 


### PR DESCRIPTION
## Summary

* Added [[Quarkus coroutine support](https://quarkus.io/guides/kotlin?utm_source=chatgpt.com#coroutines-support)](https://quarkus.io/guides/kotlin?utm_source=chatgpt.com#coroutines-support) to the `When to use` section, since Quarkus has native coroutine integration.

* Added an important note about avoiding `volatile` for synchronization, as this is a common LLM hallucination/misconception. See [[Kotlin docs: Volatiles are of no help](https://kotlinlang.org/docs/shared-mutable-state-and-concurrency.html?utm_source=chatgpt.com#volatiles-are-of-no-help)](https://kotlinlang.org/docs/shared-mutable-state-and-concurrency.html?utm_source=chatgpt.com#volatiles-are-of-no-help) for details.

