### PR TITLE
fix(bridge-opencode): discover plugins and hooks from current settings formats

### DIFF
--- a/plugins/bridges/opencode/dist/discovery.js
+++ b/plugins/bridges/opencode/dist/discovery.js
@@ -27,13 +27,21 @@ function getEnabledPlugins(projectDir) {
         try {
             const content = readFileSync(path, 'utf-8');
             const settings = JSON.parse(content);
-            if (!settings.plugins)
-                continue;
-            for (const [name, entry] of Object.entries(settings.plugins)) {
-                if (entry.enabled !== false) {
-                    // Strip @han suffix if present: "biome@han" -> "biome"
-                    const cleanName = name.replace(/@han$/, '');
-                    pluginNames.add(cleanName);
+            // Legacy `plugins` map
+            if (settings.plugins) {
+                for (const [name, entry] of Object.entries(settings.plugins)) {
+                    if (entry.enabled !== false) {
+                        // Strip @han suffix if present: "biome@han" -> "biome"
+                        pluginNames.add(name.replace(/@han$/, ''));
+                    }
+                }
+            }
+            // Current `enabledPlugins` map (what `han plugin install` writes)
+            if (settings.enabledPlugins) {
+                for (const [name, enabled] of Object.entries(settings.enabledPlugins)) {
+                    if (enabled && name.endsWith('@han')) {
+                        pluginNames.add(name.replace(/@han$/, ''));
+                    }
                 }
             }
         }
@@ -84,8 +92,10 @@ function resolvePluginPath(pluginName, marketplace, marketplaceDir) {
     const entry = marketplace.plugins.find((p) => p.name === pluginName);
     if (!entry)
         return null;
-    // source is relative to marketplace.json location (e.g. "./plugins/validation/biome")
-    const pluginPath = resolve(marketplaceDir, entry.source);
+    // source is relative to the marketplace root (the parent of .claude-plugin/),
+    // e.g. "./plugins/validation/biome" resolves to <repo>/plugins/validation/biome
+    const marketplaceRoot = dirname(marketplaceDir);
+    const pluginPath = resolve(marketplaceRoot, entry.source);
     return existsSync(pluginPath) ? pluginPath : null;
 }
 /**
@@ -200,13 +210,28 @@ function parsePluginHooks(pluginName, pluginRoot) {
         for (const [name, def] of Object.entries(config.hooks)) {
             if (!def.command)
                 continue;
+            // Events can carry Claude Code tool matchers: "PostToolUse:Edit|Write".
+            // Split the suffix off so the base event matches and the tools act as
+            // the hook's tool filter.
+            const rawEvents = def.event ?? 'Stop'; // Default event is Stop
+            const events = Array.isArray(rawEvents) ? rawEvents : [rawEvents];
+            const baseEvents = [];
+            const suffixTools = [];
+            for (const e of events) {
+                const [base, tools] = e.split(':', 2);
+                baseEvents.push(base);
+                if (tools) {
+                    suffixTools.push(...tools.split('|').map((t) => t.trim()));
+                }
+            }
+            const toolFilter = [...(def.tool_filter ?? []), ...suffixTools];
             hooks.push({
                 name,
                 pluginName,
                 pluginRoot,
-                event: def.event ?? 'Stop', // Default event is Stop
+                event: Array.isArray(rawEvents) ? baseEvents : baseEvents[0],
                 command: def.command,
-                toolFilter: def.tool_filter,
+                toolFilter: toolFilter.length > 0 ? toolFilter : undefined,
                 fileFilter: def.file_filter,
                 dirsWith: def.dirs_with,
                 dirTest: def.dir_test,

--- a/plugins/bridges/opencode/src/discovery.ts
+++ b/plugins/bridges/opencode/src/discovery.ts
@@ -21,7 +21,10 @@ interface PluginEntry {
 }
 
 interface ClaudeSettings {
+  /** Legacy map: { "biome@han": { "enabled": true } } */
   plugins?: Record<string, PluginEntry>;
+  /** Current Claude Code map: { "biome@han": true } */
+  enabledPlugins?: Record<string, boolean>;
 }
 
 interface MarketplacePlugin {
@@ -50,13 +53,23 @@ function getEnabledPlugins(projectDir: string): string[] {
     try {
       const content = readFileSync(path, 'utf-8');
       const settings: ClaudeSettings = JSON.parse(content);
-      if (!settings.plugins) continue;
 
-      for (const [name, entry] of Object.entries(settings.plugins)) {
-        if (entry.enabled !== false) {
-          // Strip @han suffix if present: "biome@han" -> "biome"
-          const cleanName = name.replace(/@han$/, '');
-          pluginNames.add(cleanName);
+      // Legacy `plugins` map
+      if (settings.plugins) {
+        for (const [name, entry] of Object.entries(settings.plugins)) {
+          if (entry.enabled !== false) {
+            // Strip @han suffix if present: "biome@han" -> "biome"
+            pluginNames.add(name.replace(/@han$/, ''));
+          }
+        }
+      }
+
+      // Current `enabledPlugins` map (what `han plugin install` writes)
+      if (settings.enabledPlugins) {
+        for (const [name, enabled] of Object.entries(settings.enabledPlugins)) {
+          if (enabled && name.endsWith('@han')) {
+            pluginNames.add(name.replace(/@han$/, ''));
+          }
         }
       }
     } catch {
@@ -114,8 +127,10 @@ function resolvePluginPath(
   const entry = marketplace.plugins.find((p) => p.name === pluginName);
   if (!entry) return null;
 
-  // source is relative to marketplace.json location (e.g. "./plugins/validation/biome")
-  const pluginPath = resolve(marketplaceDir, entry.source);
+  // source is relative to the marketplace root (the parent of .claude-plugin/),
+  // e.g. "./plugins/validation/biome" resolves to <repo>/plugins/validation/biome
+  const marketplaceRoot = dirname(marketplaceDir);
+  const pluginPath = resolve(marketplaceRoot, entry.source);
   return existsSync(pluginPath) ? pluginPath : null;
 }
 
@@ -255,13 +270,30 @@ function parsePluginHooks(
     for (const [name, def] of Object.entries(config.hooks)) {
       if (!def.command) continue;
 
+      // Events can carry Claude Code tool matchers: "PostToolUse:Edit|Write".
+      // Split the suffix off so the base event matches and the tools act as
+      // the hook's tool filter.
+      const rawEvents = def.event ?? 'Stop'; // Default event is Stop
+      const events = Array.isArray(rawEvents) ? rawEvents : [rawEvents];
+      const baseEvents: string[] = [];
+      const suffixTools: string[] = [];
+      for (const e of events) {
+        const [base, tools] = e.split(':', 2);
+        baseEvents.push(base);
+        if (tools) {
+          suffixTools.push(...tools.split('|').map((t) => t.trim()));
+        }
+      }
+
+      const toolFilter = [...(def.tool_filter ?? []), ...suffixTools];
+
       hooks.push({
         name,
         pluginName,
         pluginRoot,
-        event: def.event ?? 'Stop', // Default event is Stop
+        event: Array.isArray(rawEvents) ? baseEvents : baseEvents[0],
         command: def.command,
-        toolFilter: def.tool_filter,
+        toolFilter: toolFilter.length > 0 ? toolFilter : undefined,
         fileFilter: def.file_filter,
         dirsWith: def.dirs_with,
         dirTest: def.dir_test,


### PR DESCRIPTION
## Problem

The OpenCode bridge loaded but discovered **zero** plugins, hooks, and skills in every real install. Running opencode in a project with 31 Han plugins enabled produced:

```
[han] No Han plugins found. Install plugins: han plugin install --auto
```

Three separate discovery bugs, each fatal on its own:

1. **Settings key**: the bridge only read the legacy `plugins` object in `.claude/settings.json`. `han plugin install` writes the current Claude Code `enabledPlugins` boolean map, so nothing was ever found.
2. **Marketplace path resolution**: plugin `source` paths (e.g. `./plugins/validation/biome`) were resolved relative to `.claude-plugin/` instead of the marketplace root, so every resolved path failed the exists check. Claude Code resolves sources relative to the marketplace root (parent of `.claude-plugin/`).
3. **Event tool matchers**: han-plugin.yml events use Claude Code matcher syntax (`PostToolUse:Edit|Write|NotebookEdit`), but `getHooksByEvent` compared exact strings, so no PostToolUse hook ever matched.

## Fix

- Read both `plugins` (legacy, `enabled !== false`) and `enabledPlugins` (current, `@han`-suffixed booleans), merging across user/project/local settings.
- Resolve marketplace sources against `dirname(marketplaceDir)`.
- Split `Event:Tool|Matcher` suffixes during han-plugin.yml parsing: base string becomes the event, suffix tools merge into `toolFilter`.

## Verification

Against a live opencode session in the han repo (31 plugins enabled):

- Before: `No Han plugins found`
- After: `[han] Discovered 25 plugins: 0 PreToolUse, 5 PostToolUse, 19 Stop hooks, 102 skills, 0 disciplines`

(25 of 31 resolve; the 6 misses are enabled names with no marketplace entry of the same name: accessibility, content, documentation, frontend, plugin-development, prompts. Separate naming/alias question, not a bridge bug.)

## Also worth knowing

`opencode-plugin-han` is referenced by `han setup --agent opencode` as an npm spec but is not published to npm (404), so the generated project config currently cannot load the bridge. Publishing it (or documenting a file:// install) is a follow-up.