### PR TITLE
Harness spec refresh: Claude Code 2.1.215 + bridge updates for Codex, Kiro, Gemini, opencode, Antigravity

### DIFF
--- a/packages/han/bun.lock
+++ b/packages/han/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@thebushidocollective/han",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.72.1",
+        "@anthropic-ai/sdk": "^0.112.3",
         "@tanstack/react-virtual": "^3.13.13",
         "drizzle-orm": "^0.38.0",
         "highlight.js": "^11.11.1",
@@ -16,7 +16,7 @@
         "recyclerlistview": "^4.2.3",
       },
       "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.2.32",
+        "@anthropic-ai/claude-agent-sdk": "0.3.215",
         "@biomejs/biome": "2.3.7",
         "@bufbuild/buf": "^1.65.0",
         "@bufbuild/protobuf": "^2.11.0",
@@ -77,9 +77,25 @@
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-mkOh+Wwawzuf5wa30bvc4nA+Qb6DIrGWgBhRR/Pw4T9nsgYait8izvXkNyU78D6Wcu3Z+KUdwCmLCxlWjEotYA=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.32", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.33.5", "@img/sharp-darwin-x64": "^0.33.5", "@img/sharp-linux-arm": "^0.33.5", "@img/sharp-linux-arm64": "^0.33.5", "@img/sharp-linux-x64": "^0.33.5", "@img/sharp-linuxmusl-arm64": "^0.33.5", "@img/sharp-linuxmusl-x64": "^0.33.5", "@img/sharp-win32-x64": "^0.33.5" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-8AtsSx/M9jxd0ihS08eqa7VireTEuwQy0i1+6ZJX93LECT6Svlf47dPJiAm7JB+BhVMmwTfQeS6x1akIcCfvbQ=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.215", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.215", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.215", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.215", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.215", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.215", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.215", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.215", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.215" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-fBktJCwfu8ZeOSnnSLcWVkIHyp/pjouJsGVGtRnQ0HkcRuOReIbRcB/6n2O5dYV331Ok+MfdGHiPaTORj7pCtQ=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.72.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MiUnue7qN7DvLIoYHgkedN2z05mRf2CutBzjXXY2krzOhG2r/rIfISS2uVkNLikgToB5hYIzw+xp2jdOtRkqYQ=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.215", "", { "os": "darwin", "cpu": "arm64" }, "sha512-KIOe3N/ypVIdsI7fnJUHT0Djei1RH01TbxK6LI2mgoHKZ6NVDt/Q9kQ1+On3b/l899RhE6C1SMAiQ0iB4sbkjA=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.215", "", { "os": "darwin", "cpu": "x64" }, "sha512-cyjfQgkgF/zZbSJP6uJpPXoIJE/gYFOgz+u/SjklvakcO56BpEnsbdl/oHVu5G8GCw69V11hKFZ8T8YsVOiv2w=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.215", "", { "os": "linux", "cpu": "arm64" }, "sha512-lb7ayxZeWLiEhlOjzF8oX+DdJHrVgR1hvwkwRdYo+LgTT3hSxv6h43sheS3hZ1I9LYvOTKWa2E0O1EnffOzyCg=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.215", "", { "os": "linux", "cpu": "arm64" }, "sha512-dXMR8afbZCFWUKQGyvn9swDYYvMtZWGqqbZ994ahS7HvGN4AgF63uvojHVErW1Xxn2601Bm+eCYQt+BSLk6iZQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.215", "", { "os": "linux", "cpu": "x64" }, "sha512-Iivu3oq7hIEc81dpTu1W0GJ/kCE8TRtj9tb+wdZCp1grsuGEJiS3Bh1tLxCrhLOTDxPggK6xZGVN/RPJh84ywA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.215", "", { "os": "linux", "cpu": "x64" }, "sha512-jSmrjSupnWtw8/I1Wmr32J6lB02gFXytmNbse4kcLEgH6UGtdZckKnDVnh/ejHma4QE9WGSn54xLsSFnjHVrRg=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.215", "", { "os": "win32", "cpu": "arm64" }, "sha512-9Xtpwd4DzfObOycDkfYfQ7clhWoFu2fmRqmMZWyQRyk2mEHWR3gLBwUgpfjYb6m4Fke9eTmIx2lXDG2i1OaBzA=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.215", "", { "os": "win32", "cpu": "x64" }, "sha512-DkPwdc1zS6KIf6YNKXhlqAw95wnjG8Uh5bSXRrFA+MxsaWedlVFeja6zFM5uZ84ouGrcHEeU3PGUcGaKR1U4cQ=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.112.3", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-wjcozJlitVIuBEw9cj/xBuRznwkhcLmXmNzlFoeHbh4AvrDG3HGZrdvEOTTmobcbhjGkfOpKbmDTCQ4s9LQvCg=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -259,19 +275,21 @@
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
 
     "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
 
@@ -279,15 +297,15 @@
 
     "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
 
     "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
 
@@ -295,11 +313,11 @@
 
     "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
 
     "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
 
@@ -307,7 +325,7 @@
 
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@isaacs/ttlcache": ["@isaacs/ttlcache@1.4.1", "", {}, "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA=="],
 
@@ -340,6 +358,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@next/env": ["@next/env@15.5.9", "", {}, "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg=="],
 
@@ -509,6 +529,8 @@
 
     "@sinonjs/fake-timers": ["@sinonjs/fake-timers@10.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.0" } }, "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.13", "", { "dependencies": { "@tanstack/virtual-core": "3.13.13" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4o6oPMDvQv+9gMi8rE6gWmsOjtUZUYIJHv7EB+GblyYdi8U6OqLl8rhHWIUZSL1dUU2dPwTdTgybCKf9EjIrQg=="],
@@ -575,13 +597,17 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "anser": ["anser@1.4.10", "", {}, "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww=="],
 
@@ -623,6 +649,8 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.9", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-V8fbOCSeOFvlDj7LLChUcqbZrdKD9RU/VR260piF1790vT0mfLSwGc/Qzxv3IqiTukOpNtItePa0HBpMAj7MDg=="],
 
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -634,6 +662,12 @@
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "caller-callsite": ["caller-callsite@2.0.0", "", { "dependencies": { "callsites": "^2.0.0" } }, "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ=="],
 
@@ -685,9 +719,19 @@
 
     "connect": ["connect@3.7.0", "", { "dependencies": { "debug": "2.6.9", "finalhandler": "1.1.2", "parseurl": "~1.3.3", "utils-merge": "1.0.1" } }, "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cosmiconfig": ["cosmiconfig@5.2.1", "", { "dependencies": { "import-fresh": "^2.0.0", "is-directory": "^0.3.1", "js-yaml": "^3.13.1", "parse-json": "^4.0.0" } }, "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA=="],
 
@@ -711,6 +755,8 @@
 
     "drizzle-orm": ["drizzle-orm@0.38.4", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/react": ">=18", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "react": ">=18", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/react", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "knex", "kysely", "mysql2", "pg", "postgres", "react", "sql.js", "sqlite3"] }, "sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
@@ -728,6 +774,12 @@
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "error-stack-parser": ["error-stack-parser@2.1.4", "", { "dependencies": { "stackframe": "^1.3.4" } }, "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "es-toolkit": ["es-toolkit@1.42.0", "", {}, "sha512-SLHIyY7VfDJBM8clz4+T2oquwTQxEzu263AyhVK4jREOAwJ+8eebaa4wM3nlvnAqhDrMm2EsA6hWHaQsMPQ1nA=="],
 
@@ -747,11 +799,25 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.0", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA=="],
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
 
     "fb-dotslash": ["fb-dotslash@0.5.8", "", { "bin": { "dotslash": "bin/dotslash" } }, "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA=="],
 
@@ -767,13 +833,15 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "flow-enums-runtime": ["flow-enums-runtime@0.0.6", "", {}, "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw=="],
 
-    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
@@ -789,11 +857,17 @@
 
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
     "get-package-type": ["get-package-type@0.1.0", "", {}, "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w=="],
 
     "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -805,6 +879,8 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hermes-compiler": ["hermes-compiler@0.14.0", "", {}, "sha512-clxa193o+GYYwykWVFfpHduCATz8fR5jvU7ngXpfKHj+E9hr9vjLNtdLSEe8MUbObvVexV3wcyxQ00xTPIrB1Q=="],
@@ -815,9 +891,13 @@
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
+    "hono": ["hono@4.12.31", "", {}, "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
 
@@ -845,6 +925,10 @@
 
     "invariant": ["invariant@2.2.4", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="],
 
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
@@ -860,6 +944,8 @@
     "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": "cli.js" }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
@@ -904,6 +990,10 @@
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -961,7 +1051,13 @@
 
     "marky": ["marky@1.3.0", "", {}, "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -997,9 +1093,9 @@
 
     "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -1015,7 +1111,7 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "next": ["next@15.5.9", "", { "dependencies": { "@next/env": "15.5.9", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.7", "@next/swc-darwin-x64": "15.5.7", "@next/swc-linux-arm64-gnu": "15.5.7", "@next/swc-linux-arm64-musl": "15.5.7", "@next/swc-linux-x64-gnu": "15.5.7", "@next/swc-linux-x64-musl": "15.5.7", "@next/swc-win32-arm64-msvc": "15.5.7", "@next/swc-win32-x64-msvc": "15.5.7", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg=="],
 
@@ -1035,7 +1131,9 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
-    "on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -1069,6 +1167,8 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -1076,6 +1176,8 @@
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
@@ -1089,9 +1191,15 @@
 
     "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
     "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
 
@@ -1117,6 +1225,8 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
@@ -1131,17 +1241,21 @@
 
     "rollup": ["rollup@4.54.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.54.0", "@rollup/rollup-android-arm64": "4.54.0", "@rollup/rollup-darwin-arm64": "4.54.0", "@rollup/rollup-darwin-x64": "4.54.0", "@rollup/rollup-freebsd-arm64": "4.54.0", "@rollup/rollup-freebsd-x64": "4.54.0", "@rollup/rollup-linux-arm-gnueabihf": "4.54.0", "@rollup/rollup-linux-arm-musleabihf": "4.54.0", "@rollup/rollup-linux-arm64-gnu": "4.54.0", "@rollup/rollup-linux-arm64-musl": "4.54.0", "@rollup/rollup-linux-loong64-gnu": "4.54.0", "@rollup/rollup-linux-ppc64-gnu": "4.54.0", "@rollup/rollup-linux-riscv64-gnu": "4.54.0", "@rollup/rollup-linux-riscv64-musl": "4.54.0", "@rollup/rollup-linux-s390x-gnu": "4.54.0", "@rollup/rollup-linux-x64-gnu": "4.54.0", "@rollup/rollup-linux-x64-musl": "4.54.0", "@rollup/rollup-openharmony-arm64": "4.54.0", "@rollup/rollup-win32-arm64-msvc": "4.54.0", "@rollup/rollup-win32-ia32-msvc": "4.54.0", "@rollup/rollup-win32-x64-gnu": "4.54.0", "@rollup/rollup-win32-x64-msvc": "4.54.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
-    "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serialize-error": ["serialize-error@2.1.0", "", {}, "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw=="],
 
-    "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
@@ -1154,6 +1268,14 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -1177,7 +1299,9 @@
 
     "stacktrace-parser": ["stacktrace-parser@0.1.11", "", { "dependencies": { "type-fest": "^0.7.1" } }, "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg=="],
 
-    "statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 
@@ -1225,6 +1349,8 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
@@ -1238,6 +1364,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
@@ -1277,6 +1405,8 @@
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1297,6 +1427,8 @@
 
     "@react-native/codegen/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
+    "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+
     "@react-native/dev-middleware/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "@types/marked-terminal/marked": ["marked@11.2.0", "", { "bin": "bin/marked.js" }, "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw=="],
@@ -1310,6 +1442,8 @@
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@6.0.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.1.0", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.7.2" } }, "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg=="],
 
     "babel-plugin-relay/graphql": ["graphql@15.3.0", "", {}, "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "caller-callsite/callsites": ["callsites@2.0.0", "", {}, "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ=="],
 
@@ -1331,17 +1465,13 @@
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "connect/finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
+
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "drizzle-kit/esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
-    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "finalhandler/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
-
     "glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
-
-    "http-errors/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1359,7 +1489,11 @@
 
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "metro/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
     "metro/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "metro/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 
@@ -1391,47 +1525,13 @@
 
     "react-native/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
-    "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "send/on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
-    "send/statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
-
-    "sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
-
-    "sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
-
-    "sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
-
-    "sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
-
-    "sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
-
-    "sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
-
-    "sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
-
-    "sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
-
-    "sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
-
-    "sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
-
-    "sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
-
-    "sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
-
-    "sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
-
-    "sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
-
-    "sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
-
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "test-exclude/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -1503,6 +1603,8 @@
 
     "@react-native/codegen/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "@react-native/dev-middleware/serve-static/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+
     "@types/minimatch/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "babel-jest/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -1530,6 +1632,12 @@
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "connect/finalhandler/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
+
+    "connect/finalhandler/on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
+
+    "connect/finalhandler/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -1579,8 +1687,6 @@
 
     "drizzle-kit/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
 
-    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
     "glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "jest-message-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -1591,7 +1697,11 @@
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
+    "metro/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
     "metro/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "metro/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "metro/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -1604,8 +1714,6 @@
     "react-native/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "react-native/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -1687,6 +1795,10 @@
 
     "@react-native/codegen/yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "@react-native/dev-middleware/serve-static/send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "@react-native/dev-middleware/serve-static/send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
     "babel-plugin-macros/cosmiconfig/import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -1724,6 +1836,8 @@
     "@react-native/codegen/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@react-native/codegen/yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "metro/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/packages/han/lib/commands/plugin/generate-hooks.ts
+++ b/packages/han/lib/commands/plugin/generate-hooks.ts
@@ -38,8 +38,9 @@ interface ClaudeHookGroup {
 }
 
 interface ClaudeHookEntry {
-  type: 'command' | 'prompt';
+  type: 'command' | 'http' | 'mcp_tool' | 'prompt' | 'agent';
   command?: string;
+  args?: string[];
   prompt?: string;
   timeout?: number;
   async?: boolean;
@@ -92,7 +93,9 @@ export function generateHooksJson(
 
     for (const [eventType, toolMatcher] of parsedEvents) {
       const isToolUseEvent =
-        eventType === 'PostToolUse' || eventType === 'PreToolUse';
+        eventType === 'PostToolUse' ||
+        eventType === 'PreToolUse' ||
+        eventType === 'PostToolUseFailure';
       // All hooks are async by default unless explicitly marked sync
       const isAsync = !hookDef.sync;
 
@@ -138,19 +141,51 @@ export function generateHooksJson(
     return null;
   }
 
-  // Build the final hooks object with deterministic key order
+  // Build the final hooks object with deterministic key order.
+  // Events not in this list are appended in sorted order so that
+  // newly added Claude Code events are never silently dropped.
   const orderedEvents: HookEventType[] = [
     'SessionStart',
+    'Setup',
     'UserPromptSubmit',
+    'UserPromptExpansion',
     'PreToolUse',
+    'PermissionRequest',
+    'PermissionDenied',
     'PostToolUse',
+    'PostToolUseFailure',
+    'PostToolBatch',
+    'Notification',
+    'MessageDisplay',
     'Stop',
     'SubagentStop',
     'SubagentStart',
+    'TaskCreated',
+    'TaskCompleted',
+    'StopFailure',
+    'TeammateIdle',
+    'InstructionsLoaded',
+    'ConfigChange',
+    'CwdChanged',
+    'FileChanged',
+    'WorktreeCreate',
+    'WorktreeRemove',
+    'PreCompact',
+    'PostCompact',
+    'Elicitation',
+    'ElicitationResult',
+    'SessionEnd',
+  ];
+
+  const orderedKeys = [
+    ...orderedEvents,
+    ...[...eventGroups.keys()]
+      .filter((e) => !orderedEvents.includes(e as HookEventType))
+      .sort(),
   ];
 
   const hooksObj: Record<string, ClaudeHookGroup[]> = {};
-  for (const event of orderedEvents) {
+  for (const event of orderedKeys) {
     const groups = eventGroups.get(event);
     if (groups) {
       hooksObj[event] = groups;

--- a/packages/han/lib/hooks/hook-config.ts
+++ b/packages/han/lib/hooks/hook-config.ts
@@ -13,48 +13,74 @@ import { findDirectoriesWithMarkers } from './hook-cache.ts';
 
 /**
  * Claude Code hook event types that can trigger han hooks.
- * Complete as of Claude Code 2.1.63.
+ * Complete as of Claude Code 2.1.215.
  */
 export type HookEventType =
   | 'SessionStart'
+  | 'Setup'
   | 'UserPromptSubmit'
+  | 'UserPromptExpansion'
   | 'PreToolUse'
   | 'PermissionRequest'
+  | 'PermissionDenied'
   | 'PostToolUse'
   | 'PostToolUseFailure'
+  | 'PostToolBatch'
   | 'Notification'
+  | 'MessageDisplay'
   | 'SubagentStart'
   | 'SubagentStop'
-  | 'Stop'
-  | 'TeammateIdle'
+  | 'TaskCreated'
   | 'TaskCompleted'
+  | 'Stop'
+  | 'StopFailure'
+  | 'TeammateIdle'
+  | 'InstructionsLoaded'
   | 'ConfigChange'
+  | 'CwdChanged'
+  | 'FileChanged'
   | 'WorktreeCreate'
   | 'WorktreeRemove'
   | 'PreCompact'
+  | 'PostCompact'
+  | 'Elicitation'
+  | 'ElicitationResult'
   | 'SessionEnd';
 
 /**
  * Valid base event types for shorthand parsing validation.
- * Complete as of Claude Code 2.1.63.
+ * Complete as of Claude Code 2.1.215.
  */
 const VALID_EVENT_TYPES = new Set<string>([
   'SessionStart',
+  'Setup',
   'UserPromptSubmit',
+  'UserPromptExpansion',
   'PreToolUse',
   'PermissionRequest',
+  'PermissionDenied',
   'PostToolUse',
   'PostToolUseFailure',
+  'PostToolBatch',
   'Notification',
+  'MessageDisplay',
   'SubagentStart',
   'SubagentStop',
-  'Stop',
-  'TeammateIdle',
+  'TaskCreated',
   'TaskCompleted',
+  'Stop',
+  'StopFailure',
+  'TeammateIdle',
+  'InstructionsLoaded',
   'ConfigChange',
+  'CwdChanged',
+  'FileChanged',
   'WorktreeCreate',
   'WorktreeRemove',
   'PreCompact',
+  'PostCompact',
+  'Elicitation',
+  'ElicitationResult',
   'SessionEnd',
 ]);
 

--- a/packages/han/package.json
+++ b/packages/han/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thebushidocollective/han",
 	"version": "3.19.0",
-	"description": "CLI for installing and managing curated Claude Code plugins from the Han marketplace (v3.4)",
+	"description": "CLI for installing and managing curated plugins for AI coding agents from the Han marketplace",
 	"main": "dist/lib/main.js",
 	"types": "dist/lib/main.d.ts",
 	"type": "module",
@@ -59,7 +59,7 @@
 		"@thebushidocollective/han-win32-x64": "1.31.5"
 	},
 	"devDependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.2.32",
+		"@anthropic-ai/claude-agent-sdk": "0.3.215",
 		"@biomejs/biome": "2.3.7",
 		"@bufbuild/buf": "^1.65.0",
 		"@bufbuild/protobuf": "^2.11.0",
@@ -109,7 +109,7 @@
 		"yaml": "^2.8.1"
 	},
 	"dependencies": {
-		"@anthropic-ai/sdk": "^0.72.1",
+		"@anthropic-ai/sdk": "^0.112.3",
 		"@tanstack/react-virtual": "^3.13.13",
 		"drizzle-orm": "^0.38.0",
 		"highlight.js": "^11.11.1",

--- a/plugins/bridges/antigravity/CHANGELOG.md
+++ b/plugins/bridges/antigravity/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Discover enabled plugins from the current `enabledPlugins` settings map in
+  addition to the legacy `plugins` object
+- Resolve marketplace plugin sources relative to the marketplace root
+- Split `Event:Tool|Tool` matcher suffixes so PostToolUse hooks match
+
 ## [0.1.0] - 2026-07-15
 
 ### Added

--- a/plugins/bridges/antigravity/src/discovery.ts
+++ b/plugins/bridges/antigravity/src/discovery.ts
@@ -21,7 +21,10 @@ interface PluginEntry {
 }
 
 interface ClaudeSettings {
+  /** Legacy map: { "biome@han": { "enabled": true } } */
   plugins?: Record<string, PluginEntry>
+  /** Current Claude Code map: { "biome@han": true } */
+  enabledPlugins?: Record<string, boolean>
 }
 
 interface MarketplacePlugin {
@@ -50,13 +53,24 @@ function getEnabledPlugins(projectDir: string): string[] {
     try {
       const content = readFileSync(path, "utf-8")
       const settings: ClaudeSettings = JSON.parse(content)
-      if (!settings.plugins) continue
 
-      for (const [name, entry] of Object.entries(settings.plugins)) {
-        if (entry.enabled !== false) {
-          // Strip @han suffix if present: "biome@han" -> "biome"
-          const cleanName = name.replace(/@han$/, "")
-          pluginNames.add(cleanName)
+      // Legacy `plugins` map
+      if (settings.plugins) {
+        for (const [name, entry] of Object.entries(settings.plugins)) {
+          if (entry.enabled !== false) {
+            // Strip @han suffix if present: "biome@han" -> "biome"
+            const cleanName = name.replace(/@han$/, "")
+            pluginNames.add(cleanName)
+          }
+        }
+      }
+
+      // Current `enabledPlugins` map (what `han plugin install` writes)
+      if (settings.enabledPlugins) {
+        for (const [name, enabled] of Object.entries(settings.enabledPlugins)) {
+          if (enabled && name.endsWith("@han")) {
+            pluginNames.add(name.replace(/@han$/, ""))
+          }
         }
       }
     } catch {
@@ -115,7 +129,10 @@ function resolvePluginPath(
   const entry = marketplace.plugins.find((p) => p.name === pluginName)
   if (!entry) return null
 
-  const pluginPath = resolve(marketplaceDir, entry.source)
+  // source is relative to the marketplace root (the parent of .claude-plugin/),
+  // e.g. "./plugins/validation/biome" resolves to <repo>/plugins/validation/biome
+  const marketplaceRoot = dirname(marketplaceDir)
+  const pluginPath = resolve(marketplaceRoot, entry.source)
   return existsSync(pluginPath) ? pluginPath : null
 }
 
@@ -251,13 +268,30 @@ function parsePluginHooks(
     for (const [name, def] of Object.entries(config.hooks)) {
       if (!def.command) continue
 
+      // Events can carry Claude Code tool matchers: "PostToolUse:Edit|Write".
+      // Split the suffix off so the base event matches and the tools act as
+      // the hook's tool filter.
+      const rawEvents = def.event ?? "Stop" // Default event is Stop
+      const events = Array.isArray(rawEvents) ? rawEvents : [rawEvents]
+      const baseEvents: string[] = []
+      const suffixTools: string[] = []
+      for (const e of events) {
+        const [base, tools] = e.split(":", 2)
+        baseEvents.push(base)
+        if (tools) {
+          suffixTools.push(...tools.split("|").map((t) => t.trim()))
+        }
+      }
+
+      const toolFilter = [...(def.tool_filter ?? []), ...suffixTools]
+
       hooks.push({
         name,
         pluginName,
         pluginRoot,
-        event: def.event ?? "Stop",
+        event: Array.isArray(rawEvents) ? baseEvents : baseEvents[0],
         command: def.command,
-        toolFilter: def.tool_filter,
+        toolFilter: toolFilter.length > 0 ? toolFilter : undefined,
         fileFilter: def.file_filter,
         dirsWith: def.dirs_with,
         dirTest: def.dir_test,

--- a/plugins/bridges/codex/CHANGELOG.md
+++ b/plugins/bridges/codex/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- rewrite the bridge for Codex's real hook system (Claude-Code-style lifecycle hooks behind `[features] hooks = true`), replacing the previous implementation that was modeled on a nonexistent OpenCode-style JS plugin API. The bridge is now a stdio JSON CLI (`npx -y codex-plugin-han <event>`) covering all 10 Codex events: session-start, user-prompt-submit, pre-tool-use, permission-request, post-tool-use, pre-compact, post-compact, subagent-start, subagent-stop, stop
+- PreToolUse failures now deny via `hookSpecificOutput.permissionDecision`, PostToolUse failures feed back via `decision: "block"`, and Stop/SubagentStop failures continue the turn via `decision: "block"`
+- map Codex tool names for Han matching: `apply_patch` -> Edit, `Bash` -> Bash, `spawn_agent` -> Agent, `mcp__*` passthrough; file paths extracted from apply_patch headers
+
+### Fixed
+
+- discovery: read `enabledPlugins` boolean map in addition to the legacy `plugins` map in settings files
+- discovery: resolve marketplace plugin `source` paths relative to the marketplace root (parent of `.claude-plugin/`)
+- discovery: split Claude Code tool-matcher suffixes in event strings (`PostToolUse:Edit|Write`) into base event + tool filter
+- README/plugin metadata: correct install command (`han plugin install codex@han`) and document the real integration (`~/.codex/config.toml` + `~/.codex/hooks.json`)
+
 ## [0.1.0] - 2026-03-02
 
 ### Added

--- a/plugins/bridges/codex/README.md
+++ b/plugins/bridges/codex/README.md
@@ -1,44 +1,59 @@
 # Han Bridge for Codex CLI
 
-Bridge plugin that brings Han's full plugin ecosystem to [OpenAI Codex CLI](https://developers.openai.com/codex/) — validation hooks, core guidelines, 400+ skills, and 25 agent disciplines.
+Bridge plugin that brings Han's full plugin ecosystem to [OpenAI Codex CLI](https://developers.openai.com/codex/) — validation hooks, core guidelines, skills, and disciplines.
 
 ## What This Does
 
 Han plugins define validation hooks, specialized skills, and agent disciplines that run during Claude Code sessions. This bridge makes the entire ecosystem work in Codex CLI:
 
 1. **Hooks** — PreToolUse, PostToolUse, and Stop validation (biome, eslint, tsc, etc.) with parallel execution
-2. **Guidelines** — Core principles (professional honesty, no excuses, skill selection) injected into every LLM call
+2. **Guidelines** — Core principles (professional honesty, no excuses, skill selection) injected on session start
 3. **Datetime** — Current time injected on every user prompt
-4. **Skills** — 400+ coding skills loadable on demand via `han_skills` tool
-5. **Disciplines** — 25 agent personas (frontend, backend, SRE, security, etc.) with system prompt injection
-6. **Events** — Unified JSONL logging with `provider: "codex"` for Browse UI visibility
+4. **PreToolUse blocking** — JSON permission decisions deny tool execution per Codex convention
+5. **Events** — Unified JSONL logging with `provider: "codex"` for Browse UI visibility
 
 ## Coverage Matrix
 
-| Claude Code Hook | Codex Equivalent | Status |
+| Claude Code Hook | Codex Hook | Status |
 |---|---|---|
-| PostToolUse | `tool.execute.after` | Implemented |
-| PreToolUse | `tool.execute.before` | Implemented |
-| Stop | `stop` + `session.idle` | Implemented |
-| SessionStart | `experimental.chat.system.transform` | Implemented |
-| UserPromptSubmit | `chat.message` | Implemented |
-| SubagentPrompt | `tool.execute.before` (Task/agent) | Implemented |
-| SubagentStart/Stop | — | Not available |
-| MCP tool events | — | Not available |
-| Permission denial | — | Not available |
+| SessionStart | `SessionStart` | Implemented |
+| UserPromptSubmit | `UserPromptSubmit` | Implemented |
+| PreToolUse | `PreToolUse` | Implemented |
+| — | `PermissionRequest` | Implemented (runs PreToolUse hooks) |
+| PostToolUse | `PostToolUse` | Implemented |
+| Stop | `Stop` | Implemented |
+| SubagentStop | `SubagentStop` | Implemented (runs Stop hooks) |
+| SubagentStart | `SubagentStart` | Available (no-op) |
+| PreCompact | `PreCompact` | Available (no-op) |
+| PostCompact | `PostCompact` | Available (no-op) |
+
+## Key Difference from OpenCode Bridge
+
+The OpenCode bridge is an **in-process JS plugin** that hooks into OpenCode's runtime. The Codex bridge is a **CLI tool** that Codex hooks call as shell commands.
+
+This is because Codex's hook system is shell-based (like Claude Code), not plugin-based (like OpenCode). Each Codex hook calls `npx -y codex-plugin-han <event>`, which:
+
+1. Reads JSON from stdin (Codex's hook payload)
+2. Maps Codex tool names to Claude Code tool names
+3. Discovers and executes matching Han hooks
+4. Outputs a JSON decision to stdout (all logging goes to stderr)
 
 ## Validation Flow
 
-### PreToolUse (Pre-Execution)
+### PreToolUse (Pre-Execution Gate)
 
-Runs before a tool executes via `tool.execute.before`:
+Runs before a tool executes via Codex's `PreToolUse` hook:
 
 ```
 Agent about to run a tool
-  -> Codex fires tool.execute.before
-  -> Bridge matches PreToolUse hooks by tool name
+  -> Codex calls: npx -y codex-plugin-han pre-tool-use
+  -> Bridge reads stdin JSON { tool_name: "apply_patch", ... }
+  -> Maps apply_patch -> Edit (Claude Code name)
+  -> Matches PreToolUse hooks by tool name
   -> Runs matching hooks in parallel
-  -> Injects discipline context into subagent prompts
+  -> All pass: {} (allow)
+  -> Any fail: hookSpecificOutput.permissionDecision = "deny"
+     (reason sent to the agent)
 ```
 
 ### PostToolUse (Primary Path - In-the-Loop)
@@ -46,33 +61,35 @@ Agent about to run a tool
 The most important hook type. When the agent edits a file:
 
 ```
-Agent edits src/app.ts via edit tool
-  -> Codex fires tool.execute.after
-  -> Bridge matches PostToolUse hooks (biome lint-async, eslint lint-async, etc.)
-  -> Runs all matching hooks in parallel as promises
-  -> Collects structured results (exit code, stdout, stderr)
-  -> Delivers feedback:
-     1. Inline: appends errors to tool output (agent sees immediately)
-     2. Async: client.session.prompt() notification (agent acts on next turn)
+Agent edits src/app.ts via apply_patch
+  -> Codex calls: npx -y codex-plugin-han post-tool-use
+  -> Bridge extracts file paths (file_path fields + patch headers)
+  -> Matches PostToolUse hooks (biome lint-async, eslint lint-async, etc.)
+  -> Runs all matching hooks in parallel
+  -> All pass: {}
+  -> Any fail: { "decision": "block", "reason": ... }
+     (reason replaces the tool result as agent feedback)
 ```
 
-### Stop (Secondary - Full Project)
+### Stop / SubagentStop (Full Project)
 
 When the agent finishes a turn:
 
 ```
 Agent signals completion
-  -> Codex fires session.idle / stop
+  -> Codex calls: npx -y codex-plugin-han stop
   -> Bridge runs Stop hooks (full project lint, typecheck, tests)
-  -> If failures: re-prompts agent via client.session.prompt()
-  -> Agent gets a new turn to fix project-wide issues
+  -> All pass: {}
+  -> Any fail: { "decision": "block", "reason": ... }
+     (Codex turns the reason into a new user prompt;
+      the agent keeps working until validation passes)
 ```
 
 ## Context Injection
 
-### SessionStart Equivalent
+### SessionStart
 
-Core guidelines are injected into every LLM call via `experimental.chat.system.transform`:
+Core guidelines are injected via `hookSpecificOutput.additionalContext`:
 
 - Professional honesty (verify before accepting claims)
 - No time estimates (use phase numbers)
@@ -80,23 +97,12 @@ Core guidelines are injected into every LLM call via `experimental.chat.system.t
 - Date handling best practices
 - Mandatory skill selection
 
-### UserPromptSubmit Equivalent
+If `HAN_DISCIPLINE` is set in the environment, that discipline's persona
+context is injected alongside the guidelines.
 
-Current local datetime is injected on every user message via `chat.message`, so the LLM always knows the current time.
+### UserPromptSubmit
 
-### SubagentPrompt Equivalent
-
-When a discipline is active and the LLM spawns a task/agent tool, the bridge injects discipline context into the subagent's prompt via `tool.execute.before`.
-
-## Hook Discovery
-
-The bridge reads installed plugins directly from the filesystem:
-
-1. **Settings files**: `~/.claude/settings.json`, `.claude/settings.json` for enabled plugins
-2. **Marketplace**: `.claude-plugin/marketplace.json` for plugin path resolution
-3. **Plugin configs**: Each plugin's `han-plugin.yml` for hook definitions
-
-No dependency on `han hook dispatch` (which is fire-and-forget). The bridge manages hook lifecycle directly.
+Current local datetime is injected on every user prompt via `additionalContext`, so the LLM always knows the current time.
 
 ## Setup
 
@@ -111,30 +117,114 @@ han plugin install --auto
 
 ### Install the Bridge
 
-**Option A: Han Marketplace** (recommended)
-
-Install via Han CLI, which makes the bridge available to Codex:
-
 ```bash
-han plugin install codex-bridge@han
+han plugin install codex@han
 ```
 
-Then add to your `~/.codex/config.toml`:
+### Enable Codex Hooks
+
+Hooks are gated behind a feature flag. Add to `~/.codex/config.toml`:
+
+```toml
+[features]
+hooks = true
+```
+
+### Wire the Hook Events
+
+Add to `~/.codex/hooks.json` (global) or `<repo>/.codex/hooks.json` (per project). Timeouts are in **seconds**:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han session-start", "timeout": 30 }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han user-prompt-submit", "timeout": 10 }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|apply_patch|Edit|Write|spawn_agent|Agent",
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han pre-tool-use", "timeout": 30 }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han permission-request", "timeout": 15 }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "apply_patch|Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han post-tool-use", "timeout": 120 }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "manual|auto",
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han pre-compact", "timeout": 10 }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han post-compact", "timeout": 10 }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han subagent-start", "timeout": 10 }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han subagent-stop", "timeout": 180 }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han stop", "timeout": 180 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### MCP Server (Complementary)
+
+Hooks handle validation and context injection. For Han's MCP tools
+(memory, codebase analysis, hook utilities), add the Han MCP server to
+`~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.han]
-command = "bun"
-args = ["run", "~/.claude/plugins/cache/han/bridges/codex/src/index.ts"]
-```
-
-**Option B: From Source**
-
-Clone the Han repository and reference the bridge directly:
-
-```toml
-[mcp_servers.han]
-command = "bun"
-args = ["run", "/path/to/han/plugins/bridges/codex/src/index.ts"]
+command = "han"
+args = ["mcp"]
 ```
 
 ### AGENTS.md Integration
@@ -155,40 +245,38 @@ For core guidelines without the full bridge, add to your project's `AGENTS.md`:
 ```
 Codex CLI Runtime
   |
-  |-- experimental.chat.system.transform ──────> SessionStart context
-  |     (every LLM call)                          (core guidelines + discipline)
+  |-- SessionStart ────────────────────────────> additionalContext
+  |     (startup/resume/clear/compact)            (core guidelines + discipline)
+  |           |
+  |           └─ han coordinator ensure ──────────┘
+  |               (Browse UI visibility)
   |
-  |-- chat.message ────────────────────────────> UserPromptSubmit context
-  |     (every user prompt)                        (current datetime)
+  |-- UserPromptSubmit ────────────────────────> additionalContext
+  |     (every user prompt)                       (current datetime)
   |
-  |-- tool.execute.before ─────────────────────> PreToolUse hooks
-  |     (before tool runs)                         (validation gates)
-  |                                                     |
-  |     └─ discipline context ──────────────────────────┘
-  |         (injected into task/agent prompts)
+  |-- PreToolUse ──────────────────────────────> PreToolUse hooks
+  |     (Bash, apply_patch, spawn_agent)          (validation gates)
+  |           |
+  |           └─ hookSpecificOutput ──────────────┘
+  |               (permissionDecision: deny)
   |
-  |-- tool.execute.after ──────────────────────> PostToolUse hooks
-  |     (edit, write, shell)                       (biome, eslint, tsc)
-  |                                                     |
-  |     ┌─ inline: mutate tool output ──────────────────┤
-  |     └─ async: client.session.prompt(noReply) ───────┘
+  |-- PermissionRequest ───────────────────────> PreToolUse hooks
+  |     (Codex about to prompt user)              |
+  |           |
+  |           └─ hookSpecificOutput ──────────────┘
+  |               (decision.behavior: deny)
   |
-  |-- session.idle ────────────────────────────> Stop hooks
-  |     (agent finished turn)                      (full project lint)
-  |                                                     |
-  |     └─ client.session.prompt() ─────────────────────┘
-  |         (re-prompts agent to fix issues)
+  |-- PostToolUse ─────────────────────────────> PostToolUse hooks
+  |     (apply_patch/Edit/Write)                  (biome, eslint, tsc)
+  |           |
+  |           └─ decision: "block" ───────────────┘
+  |               (reason = tool result feedback)
   |
-  |-- stop ────────────────────────────────────> Stop hooks (backup)
-  |     (agent signals completion)                  |
-  |                                                 └─ { continue: true }
-  |                                                     (force continuation)
-  |
-  |-- tool: han_skills ────────────────────────> Skill discovery
-  |     (LLM-callable)                             (list/search/load 400+ skills)
-  |
-  |-- tool: han_discipline ────────────────────> Agent disciplines
-  |     (LLM-callable)                             (activate/deactivate/list)
+  |-- Stop / SubagentStop ─────────────────────> Stop hooks
+  |     (agent finished turn)                     (full project lint)
+  |           |
+  |           └─ decision: "block" ───────────────┘
+  |               (reason = new user prompt)
   |
   |-- JSONL logger ────────────────────────────> Event logging
         (hook_run, hook_result, hook_file_change)  (Browse UI visibility)
@@ -197,40 +285,25 @@ Bridge Internals:
   context.ts       Core guidelines + datetime injection
   discovery.ts     Read settings + marketplace + resolve plugin paths
   skills.ts        Discover SKILL.md files from installed plugins
-  disciplines.ts   Discover discipline plugins, system prompt builder
+  disciplines.ts   Discover discipline plugins, persona context builder
   matcher.ts       Filter by tool name, file globs, dirsWith
   executor.ts      Spawn hook commands as parallel promises
-  formatter.ts     Structure results as XML-tagged agent messages
+  formatter.ts     Structure results as Codex JSON decisions
   events.ts        JSONL event logger (provider="codex")
   cache.ts         Content-hash caching (SHA-256)
 ```
 
 ## Tool Name Mapping
 
-Codex CLI uses different tool names than Claude Code:
+Codex CLI uses different tool names than Claude Code. The bridge maps them before matching Han hooks:
 
 | Codex Tool | Claude Code Equivalent |
 |---|---|
-| `shell` | `Bash` |
-| `edit` | `Edit` |
-| `write` | `Write` |
-| `read` | `Read` |
-| `list` | `Glob` |
-
-## Skills
-
-The bridge registers a `han_skills` tool that gives the LLM access to Han's full skill library (400+ skills across 95+ plugins). Skills are discovered at plugin init time by scanning each installed plugin's `skills/*/SKILL.md` files.
-
-Two actions:
-
-- **list** — Browse available skills with optional search filter
-- **load** — Load the full SKILL.md content for a specific skill (supports partial name matching)
-
-## Disciplines
-
-The bridge registers a `han_discipline` tool for activating specialized agent personas. When a discipline is active, its context is injected into every LLM call.
-
-Available disciplines include: frontend, backend, api, architecture, mobile, database, security, infrastructure, sre, performance, accessibility, quality, documentation, and more (25 total).
+| `Bash` | `Bash` |
+| `apply_patch` | `Edit` |
+| `Edit` / `Write` (apply_patch aliases) | passed through as-is |
+| `spawn_agent` | `Agent` |
+| `mcp__server__tool` | passed through as-is |
 
 ## Event Logging & Provider Architecture
 
@@ -239,17 +312,13 @@ The bridge writes Han-format JSONL events to `~/.han/codex/projects/{slug}/{sess
 Events logged:
 
 - `hook_run` / `hook_result` — Hook execution lifecycle (start, success/failure, duration)
-- `hook_file_change` — File edits detected via `tool.execute.after`
+- `hook_file_change` — File edits detected via `PostToolUse`
 
-The bridge sets `HAN_PROVIDER=codex` in the environment for child processes and starts the Han coordinator in the background. The coordinator indexes these JSONL files into SQLite and serves them through the Browse UI alongside other provider sessions.
+The bridge sets `HAN_PROVIDER=codex` in the environment for child processes and starts the Han coordinator in the background on `SessionStart`. The coordinator indexes these JSONL files into SQLite and serves them through the Browse UI alongside other provider sessions.
 
 ## Remaining Gaps
 
-These are platform limitations that cannot be bridged until Codex adds support:
-
-- **MCP tool events**: Codex may not fire `tool.execute.after` for MCP tool calls
-- **Subagent hooks**: No Codex equivalent for SubagentStart/SubagentStop
-- **Permission denial**: `tool.execute.before` cannot block tool execution (PreToolUse hooks can warn but not deny)
+- **SubagentStart context**: Codex supports `additionalContext` on SubagentStart, but the bridge has no per-session discipline state to inject (one process per event)
 - **Checkpoints**: Session-scoped checkpoint filtering is not yet implemented
 
 ## Development
@@ -260,6 +329,10 @@ cd plugins/bridges/codex
 
 # The plugin uses TypeScript directly (Bun handles it)
 # No build step required
+
+# Smoke test: every event reads stdin until EOF and prints JSON
+bun src/index.ts stop < /dev/null
+echo '{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Update File: src/x.ts\n*** End Patch"}}' | bun src/index.ts post-tool-use
 ```
 
 ## License

--- a/plugins/bridges/codex/han-plugin.yml
+++ b/plugins/bridges/codex/han-plugin.yml
@@ -5,11 +5,19 @@
 #
 # Installation:
 #   1. Install Han plugins as usual: han plugin install --auto
-#   2. Add the MCP server to ~/.codex/config.toml:
-#      [mcp_servers.han]
-#      command = "npx"
-#      args = ["-y", "codex-plugin-han"]
-#   3. Han hooks (validation, context injection) now work in Codex.
+#   2. Enable hooks in ~/.codex/config.toml:
+#        [features]
+#        hooks = true
+#   3. Wire the events in ~/.codex/hooks.json (see README.md for a
+#      ready-to-paste snippet), e.g.:
+#        {
+#          "hooks": {
+#            "Stop": [
+#              { "hooks": [ { "type": "command", "command": "npx -y codex-plugin-han stop", "timeout": 180 } ] }
+#            ]
+#          }
+#        }
+#   4. Han hooks (validation, context injection) now work in Codex.
 
 hooks: {}
 

--- a/plugins/bridges/codex/package.json
+++ b/plugins/bridges/codex/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Han bridge for Codex CLI - enables Han's validation hooks and plugin ecosystem in Codex sessions",
   "main": "src/index.ts",
+  "bin": {
+    "codex-plugin-han": "src/index.ts"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/plugins/bridges/codex/src/discovery.ts
+++ b/plugins/bridges/codex/src/discovery.ts
@@ -21,7 +21,10 @@ interface PluginEntry {
 }
 
 interface ClaudeSettings {
+  /** Legacy map: { "biome@han": { "enabled": true } } */
   plugins?: Record<string, PluginEntry>;
+  /** Current Claude Code map: { "biome@han": true } */
+  enabledPlugins?: Record<string, boolean>;
 }
 
 interface MarketplacePlugin {
@@ -50,20 +53,27 @@ function getEnabledPlugins(projectDir: string): string[] {
     try {
       const content = readFileSync(path, 'utf-8');
       const settings: ClaudeSettings = JSON.parse(content);
-      if (!settings.plugins) continue;
 
-      for (const [name, entry] of Object.entries(settings.plugins)) {
-        if (entry.enabled !== false) {
-          // Strip @han suffix if present: "biome@han" -> "biome"
-          const cleanName = name.replace(/@han$/, '');
-          pluginNames.add(cleanName);
+      // Legacy `plugins` map
+      if (settings.plugins) {
+        for (const [name, entry] of Object.entries(settings.plugins)) {
+          if (entry.enabled !== false) {
+            // Strip @han suffix if present: "biome@han" -> "biome"
+            pluginNames.add(name.replace(/@han$/, ''));
+          }
         }
       }
-    } catch (err) {
-      console.error(
-        `[han] Warning: could not read settings file ${path}:`,
-        err instanceof Error ? err.message : err
-      );
+
+      // Current `enabledPlugins` map (what `han plugin install` writes)
+      if (settings.enabledPlugins) {
+        for (const [name, enabled] of Object.entries(settings.enabledPlugins)) {
+          if (enabled && name.endsWith('@han')) {
+            pluginNames.add(name.replace(/@han$/, ''));
+          }
+        }
+      }
+    } catch {
+      // Skip unreadable settings files
     }
   }
 
@@ -100,12 +110,7 @@ function findMarketplace(projectDir: string): Marketplace | null {
     try {
       const content = readFileSync(path, 'utf-8');
       return JSON.parse(content) as Marketplace;
-    } catch (err) {
-      console.error(
-        `[han] Warning: could not parse marketplace file ${path}:`,
-        err instanceof Error ? err.message : err
-      );
-    }
+    } catch {}
   }
 
   return null;
@@ -122,8 +127,10 @@ function resolvePluginPath(
   const entry = marketplace.plugins.find((p) => p.name === pluginName);
   if (!entry) return null;
 
-  // source is relative to marketplace.json location (e.g. "./plugins/validation/biome")
-  const pluginPath = resolve(marketplaceDir, entry.source);
+  // source is relative to the marketplace root (the parent of .claude-plugin/),
+  // e.g. "./plugins/validation/biome" resolves to <repo>/plugins/validation/biome
+  const marketplaceRoot = dirname(marketplaceDir);
+  const pluginPath = resolve(marketplaceRoot, entry.source);
   return existsSync(pluginPath) ? pluginPath : null;
 }
 
@@ -137,6 +144,7 @@ interface RawHookDef {
   dirs_with?: string[];
   dir_test?: string;
   timeout?: number;
+  [key: string]: string | number | string[] | undefined;
 }
 
 interface RawPluginConfig {
@@ -208,10 +216,11 @@ function parseSimpleYaml(content: string): RawPluginConfig {
         key === 'dirs_with'
       ) {
         if (cleanValue.startsWith('[')) {
-          (hook as Record<string, unknown>)[key] = cleanValue
-            .replace(/^\[|\]$/g, '')
-            .split(',')
-            .map((s) => s.trim().replace(/^["']|["']$/g, ''));
+          if (hook)
+            hook[key] = cleanValue
+              .replace(/^\[|\]$/g, '')
+              .split(',')
+              .map((s) => s.trim().replace(/^["']|["']$/g, ''));
         } else {
           currentField = key;
         }
@@ -221,13 +230,13 @@ function parseSimpleYaml(content: string): RawPluginConfig {
 
     // Array item (6-space indent with -)
     const arrayMatch = trimmed.match(/^ {6}- (.+)$/);
-    if (arrayMatch && currentField) {
+    if (arrayMatch && currentField && hook) {
       const value = arrayMatch[1].replace(/^["']|["']$/g, '');
-      const rec = hook as Record<string, unknown>;
-      if (!rec[currentField]) {
-        rec[currentField] = [];
+      if (!hook[currentField]) {
+        hook[currentField] = [];
       }
-      (rec[currentField] as string[]).push(value);
+      const arr = hook[currentField];
+      if (Array.isArray(arr)) arr.push(value);
       continue;
     }
 
@@ -261,13 +270,30 @@ function parsePluginHooks(
     for (const [name, def] of Object.entries(config.hooks)) {
       if (!def.command) continue;
 
+      // Events can carry Claude Code tool matchers: "PostToolUse:Edit|Write".
+      // Split the suffix off so the base event matches and the tools act as
+      // the hook's tool filter.
+      const rawEvents = def.event ?? 'Stop'; // Default event is Stop
+      const events = Array.isArray(rawEvents) ? rawEvents : [rawEvents];
+      const baseEvents: string[] = [];
+      const suffixTools: string[] = [];
+      for (const e of events) {
+        const [base, tools] = e.split(':', 2);
+        baseEvents.push(base);
+        if (tools) {
+          suffixTools.push(...tools.split('|').map((t) => t.trim()));
+        }
+      }
+
+      const toolFilter = [...(def.tool_filter ?? []), ...suffixTools];
+
       hooks.push({
         name,
         pluginName,
         pluginRoot,
-        event: def.event ?? 'Stop', // Default event is Stop
+        event: Array.isArray(rawEvents) ? baseEvents : baseEvents[0],
         command: def.command,
-        toolFilter: def.tool_filter,
+        toolFilter: toolFilter.length > 0 ? toolFilter : undefined,
         fileFilter: def.file_filter,
         dirsWith: def.dirs_with,
         dirTest: def.dir_test,
@@ -276,11 +302,7 @@ function parsePluginHooks(
     }
 
     return hooks;
-  } catch (err) {
-    console.error(
-      `[han] Warning: could not parse plugin config for ${pluginName}:`,
-      err instanceof Error ? err.message : err
-    );
+  } catch {
     return [];
   }
 }

--- a/plugins/bridges/codex/src/formatter.ts
+++ b/plugins/bridges/codex/src/formatter.ts
@@ -1,12 +1,12 @@
 /**
- * Result formatting: turns raw hook results into structured messages
- * that the Codex agent can understand and act on.
+ * Result formatting: turns raw hook results into Codex hook responses.
  *
- * Output uses XML-like tags for clear structure, making it easy
- * for the LLM to parse plugin name, file, status, and error details.
+ * Codex hooks communicate via stdout JSON. The bridge formats hook
+ * results as CodexHookOutput objects with the appropriate decision
+ * and hookSpecificOutput shapes per event.
  */
 
-import type { HookResult } from './types';
+import type { CodexHookOutput, HookResult } from './types';
 
 /**
  * Format a single hook result as a structured validation block.
@@ -26,75 +26,118 @@ function formatSingleResult(result: HookResult): string {
 }
 
 /**
- * Format PostToolUse hook results for inline tool output mutation.
- *
- * Only includes failed hooks since passing validation doesn't need
- * to be surfaced to the agent.
- *
- * @returns Formatted string to append to tool output, or null if no failures
+ * Collect failure blocks from hook results.
  */
-export function formatInlineResults(results: HookResult[]): string | null {
+function failureBlocks(results: HookResult[]): string[] {
   const failures = results.filter((r) => !r.skipped && r.exitCode !== 0);
-
-  if (failures.length === 0) return null;
-
-  const blocks = failures.map(formatSingleResult).filter(Boolean);
-  if (blocks.length === 0) return null;
-
-  return ['', '--- Han Validation ---', ...blocks].join('\n');
+  return failures.map(formatSingleResult).filter(Boolean);
 }
 
 /**
- * Format PostToolUse hook results as an async notification message.
+ * Format PreToolUse hook results as a Codex permission decision.
  *
- * Used to inject validation results that the agent can act on
- * in its next turn.
- *
- * @returns Structured message for the agent, or null if no failures
+ * If any hook fails, the tool call is denied via hookSpecificOutput
+ * and the reason is sent to the agent.
  */
-export function formatNotificationResults(
-  results: HookResult[],
-  filePaths: string[]
-): string | null {
-  const failures = results.filter((r) => !r.skipped && r.exitCode !== 0);
-
-  if (failures.length === 0) return null;
-
-  const blocks = failures.map(formatSingleResult).filter(Boolean);
+export function formatPreToolUseResults(
+  results: HookResult[]
+): CodexHookOutput | null {
+  const blocks = failureBlocks(results);
   if (blocks.length === 0) return null;
 
-  const fileList = filePaths.length > 0 ? `Files: ${filePaths.join(', ')}` : '';
+  const reason = [
+    'Han pre-tool validation blocked this operation:',
+    '',
+    ...blocks,
+  ].join('\n');
 
-  return [
-    `<han-post-tool-validation${fileList ? ` files="${filePaths.join(',')}"` : ''}>`,
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+/**
+ * Format PermissionRequest hook results as a Codex allow/deny decision.
+ *
+ * If any hook fails, the permission request is denied with the reason
+ * shown to the user.
+ */
+export function formatPermissionRequestResults(
+  results: HookResult[]
+): CodexHookOutput | null {
+  const blocks = failureBlocks(results);
+  if (blocks.length === 0) return null;
+
+  const message = [
+    'Han pre-tool validation denied this operation:',
+    '',
+    ...blocks,
+  ].join('\n');
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PermissionRequest',
+      decision: {
+        behavior: 'deny',
+        message,
+      },
+    },
+  };
+}
+
+/**
+ * Format PostToolUse hook results as tool-result feedback.
+ *
+ * decision: "block" replaces the tool result with the reason, so the
+ * agent sees validation failures as feedback on its edit.
+ */
+export function formatPostToolUseResults(
+  results: HookResult[]
+): CodexHookOutput | null {
+  const blocks = failureBlocks(results);
+  if (blocks.length === 0) return null;
+
+  const reason = [
+    '<han-post-tool-validation>',
     'The following validation hooks reported issues after your last edit.',
     'Please fix these issues before continuing:',
     '',
     ...blocks,
     '</han-post-tool-validation>',
   ].join('\n');
+
+  return {
+    decision: 'block',
+    reason,
+  };
 }
 
 /**
- * Format Stop/idle hook results for re-prompting the agent.
+ * Format Stop/SubagentStop hook results as a continuation decision.
  *
- * Used when the agent finishes a turn and broader validation finds issues.
- *
- * @returns Message to send as feedback, or null if all passed
+ * decision: "block" turns the reason into a new user prompt, forcing
+ * the agent to keep working until validation passes.
  */
-export function formatStopResults(results: HookResult[]): string | null {
-  const failures = results.filter((r) => !r.skipped && r.exitCode !== 0);
-
-  if (failures.length === 0) return null;
-
-  const blocks = failures.map(formatSingleResult).filter(Boolean);
+export function formatStopResults(
+  results: HookResult[]
+): CodexHookOutput | null {
+  const blocks = failureBlocks(results);
   if (blocks.length === 0) return null;
 
-  return [
+  const reason = [
     '<han-validation-summary>',
     'Han validation hooks found issues that need to be fixed:',
     '',
     ...blocks,
     '</han-validation-summary>',
   ].join('\n');
+
+  return {
+    decision: 'block',
+    reason,
+  };
 }

--- a/plugins/bridges/codex/src/index.ts
+++ b/plugins/bridges/codex/src/index.ts
@@ -1,51 +1,47 @@
+#!/usr/bin/env bun
 /**
  * Han Bridge for Codex CLI
  *
- * Translates Codex CLI's plugin/hook events into Han hook executions,
- * enabling Han's validation pipeline to work inside Codex.
+ * CLI entry point called by Codex's hook system (Claude-Code-style
+ * lifecycle hooks, enabled with [features] hooks = true in
+ * ~/.codex/config.toml). Each Codex hook event dispatches to a handler
+ * that discovers, matches, and executes Han validation hooks.
+ *
+ * Unlike the OpenCode bridge (in-process JS plugin), this is a shell
+ * command that Codex invokes. It reads JSON from stdin, runs Han hooks,
+ * and outputs a JSON decision to stdout.
+ *
+ * Usage (from ~/.codex/hooks.json):
+ *   "command": "npx -y codex-plugin-han <event>"
+ *
+ * Events:
+ *   session-start      -> SessionStart (additionalContext + coordinator)
+ *   user-prompt-submit -> UserPromptSubmit (datetime context)
+ *   pre-tool-use       -> PreToolUse (hookSpecificOutput permissionDecision)
+ *   permission-request -> PermissionRequest (hookSpecificOutput decision)
+ *   post-tool-use      -> PostToolUse (decision block = tool feedback)
+ *   pre-compact        -> PreCompact (no-op, keeps protocol happy)
+ *   post-compact       -> PostCompact (no-op)
+ *   subagent-start     -> SubagentStart (no-op)
+ *   subagent-stop      -> SubagentStop (Stop hooks, decision block)
+ *   stop               -> Stop (decision block forces continuation)
  *
  * Architecture:
  *
- *   tool.execute.after (write/edit)
- *     -> discovery.ts finds installed plugins' PostToolUse hooks
+ *   Codex fires hook event
+ *     -> stdin JSON payload { hook_event_name, cwd, tool_name, tool_input }
+ *     -> bridge reads payload, maps Codex tool names to Claude Code names
+ *     -> discovery.ts finds installed plugins' hooks
  *     -> matcher.ts filters by tool name + file pattern
  *     -> executor.ts runs matching hook commands as parallel promises
- *     -> formatter.ts structures results into actionable feedback
- *     -> client.session.prompt() notifies agent of issues
- *
- *   session.idle (agent finished)
- *     -> discovery.ts finds installed plugins' Stop hooks
- *     -> executor.ts runs matching hooks
- *     -> formatter.ts structures results
- *     -> client.session.prompt() re-prompts agent to fix issues
- *
- *   han_skills tool (LLM-callable)
- *     -> skills.ts discovers SKILL.md from installed plugins
- *     -> LLM can list and load 400+ skills on demand
- *
- *   han_discipline tool (LLM-callable)
- *     -> disciplines.ts discovers agent personas
- *     -> System prompt injection via config hooks
- *
- * Codex CLI Extension Points:
- *   - Hooks (config.toml): on_tool_start, on_tool_end, on_turn_end
- *   - MCP servers (config.toml): Provides han_skills, han_discipline tools
- *   - AGENTS.md: Core guidelines injection
- *
- * Key difference from han's dispatch: hooks run as awaited promises,
- * not fire-and-forget. Results are collected, parsed, and delivered
- * as structured messages the agent can act on.
+ *     -> formatter.ts structures results into Codex JSON decisions
+ *     -> stdout JSON (only valid JSON goes to stdout; logs go to stderr)
  */
 
 import { isAbsolute, resolve } from 'node:path';
 import { invalidateFile } from './cache';
 import { buildPromptContext, buildSessionContext } from './context';
-import {
-  buildDisciplineContext,
-  type DisciplineInfo,
-  discoverDisciplines,
-  formatDisciplineList,
-} from './disciplines';
+import { buildDisciplineContext, discoverDisciplines } from './disciplines';
 import {
   discoverHooks,
   getHooksByEvent,
@@ -54,61 +50,84 @@ import {
 import { BridgeEventLogger } from './events';
 import { executeHooksParallel } from './executor';
 import {
-  formatInlineResults,
-  formatNotificationResults,
+  formatPermissionRequestResults,
+  formatPostToolUseResults,
+  formatPreToolUseResults,
   formatStopResults,
 } from './formatter';
 import { matchPostToolUseHooks, matchStopHooks } from './matcher';
+import { discoverAllSkills } from './skills';
 import {
-  discoverAllSkills,
-  formatSkillList,
-  loadSkillContent,
-  type SkillInfo,
-} from './skills';
-import {
-  type CodexEvent,
-  type CodexPluginContext,
+  type CodexHookOutput,
+  type CodexHookPayload,
   mapToolName,
-  type StopResult,
-  type ToolBeforeInput,
-  type ToolBeforeOutput,
-  type ToolEventInput,
-  type ToolEventOutput,
 } from './types';
 
 const PREFIX = '[han]';
 
 /**
- * Extract file path(s) from a Codex tool event.
- *
- * Codex provides tool output with title/output/metadata.
- * For edit/write tools, the file path is typically in the metadata
- * or can be inferred from the tool output.
+ * Read JSON payload from stdin.
+ * Codex passes hook context as JSON via stdin.
  */
-function extractFilePaths(
-  _input: ToolEventInput,
-  output: ToolEventOutput,
-  cwd: string
-): string[] {
-  const paths: string[] = [];
+async function readStdin(): Promise<CodexHookPayload> {
+  const chunks: Buffer[] = [];
 
-  // Check metadata for file path
-  if (output.metadata && typeof output.metadata === 'object') {
-    const meta = output.metadata;
-    if ('path' in meta && typeof meta.path === 'string') paths.push(meta.path);
-    if ('file_path' in meta && typeof meta.file_path === 'string')
-      paths.push(meta.file_path);
-    if ('filePath' in meta && typeof meta.filePath === 'string')
-      paths.push(meta.filePath);
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
   }
 
-  // Check title for file path (common pattern: "Edit: src/foo.ts")
-  if (paths.length === 0 && output.title) {
-    const titleMatch = output.title.match(
-      /(?:edit|write|create|modify):\s*(.+)/i
-    );
-    if (titleMatch) {
-      paths.push(titleMatch[1].trim());
+  const raw = Buffer.concat(chunks).toString('utf-8').trim();
+  if (!raw) return {};
+
+  try {
+    return JSON.parse(raw) as CodexHookPayload;
+  } catch {
+    console.error(`${PREFIX} Failed to parse stdin JSON`);
+    return {};
+  }
+}
+
+/**
+ * Write JSON to stdout. This is the ONLY output Codex reads.
+ */
+function writeOutput(output: CodexHookOutput): void {
+  process.stdout.write(JSON.stringify(output));
+}
+
+/**
+ * Extract file path(s) from a Codex tool payload.
+ *
+ * Edit/Write aliases carry file_path in tool_input. apply_patch carries
+ * a patch document, so file paths are pulled from its file headers.
+ */
+function extractFilePaths(payload: CodexHookPayload): string[] {
+  const paths: string[] = [];
+  const cwd = payload.cwd || process.cwd();
+  const input = payload.tool_input;
+
+  if (input) {
+    if (typeof input.file_path === 'string') paths.push(input.file_path);
+    if (typeof input.filePath === 'string') paths.push(input.filePath);
+    if (typeof input.path === 'string') paths.push(input.path);
+
+    // apply_patch: parse "*** Update File: <path>" style headers
+    for (const key of ['patch', 'input']) {
+      const text = input[key];
+      if (typeof text !== 'string') continue;
+      for (const match of text.matchAll(/^\*\*\* \w+ File: (.+)$/gm)) {
+        paths.push(match[1].trim());
+      }
+    }
+  }
+
+  if (
+    payload.tool_response &&
+    typeof payload.tool_response === 'object' &&
+    !Array.isArray(payload.tool_response)
+  ) {
+    const resp = payload.tool_response as Record<string, unknown>;
+    if (typeof resp.file_path === 'string' && !paths.includes(resp.file_path)) {
+      paths.push(resp.file_path);
     }
   }
 
@@ -117,7 +136,7 @@ function extractFilePaths(
     .map((p) => (isAbsolute(p) ? resolve(p) : resolve(cwd, p)))
     .filter((p) => {
       if (!p.startsWith(cwd)) {
-        console.error(`[han] Rejected path outside project: ${p}`);
+        console.error(`${PREFIX} Rejected path outside project: ${p}`);
         return false;
       }
       return true;
@@ -127,14 +146,12 @@ function extractFilePaths(
 /**
  * Start the Han coordinator daemon in the background.
  * The coordinator indexes JSONL event files and serves the Browse UI.
- * We pass the Codex watch path so it picks up our events.
  */
 function startCoordinator(watchDir: string): void {
   try {
     const { spawn } =
       require('node:child_process') as typeof import('node:child_process');
 
-    // Start coordinator if not already running
     const child = spawn(
       'han',
       ['coordinator', 'ensure', '--background', '--watch-path', watchDir],
@@ -149,13 +166,9 @@ function startCoordinator(watchDir: string): void {
       }
     );
 
-    // Unref so the coordinator doesn't prevent Codex from exiting
     child.unref();
-
     console.error(`${PREFIX} Coordinator ensure started (watch: ${watchDir})`);
   } catch {
-    // han CLI not installed - coordinator won't index our events
-    // but validation still works fine without it
     console.error(
       `${PREFIX} Could not start coordinator (han CLI not found). ` +
         `Browse UI won't show Codex sessions.`
@@ -164,499 +177,294 @@ function startCoordinator(watchDir: string): void {
 }
 
 /**
- * Main Codex plugin entry point.
- *
- * Codex CLI supports plugins via its config.toml hook system and MCP
- * servers. This function adapts Han's hook ecosystem to Codex's model:
- *
- * - Hook events map to Codex lifecycle hooks (on_tool_end, on_turn_end)
- * - Tools (han_skills, han_discipline) are exposed as MCP tools
- * - System prompt context is injected via AGENTS.md or config hooks
+ * Run PreToolUse hooks matching the payload's tool.
+ * Shared by the pre-tool-use and permission-request handlers.
  */
-async function hanBridgePlugin(ctx: CodexPluginContext) {
-  const { client, directory } = ctx;
-
-  // ─── Plugin Discovery ───────────────────────────────────────────────────
-  // Resolve all installed plugins to their filesystem paths.
-  // This is shared by hooks, skills, and disciplines.
-  const resolvedPlugins = resolvePluginPaths(directory);
-
-  // ─── Hook Discovery ──────────────────────────────────────────────────────
+async function runPreToolHooks(
+  payload: CodexHookPayload,
+  directory: string,
+  sessionId: string
+) {
   const allHooks = discoverHooks(directory);
-  const postToolUseHooks = getHooksByEvent(allHooks, 'PostToolUse');
   const preToolUseHooks = getHooksByEvent(allHooks, 'PreToolUse');
-  const stopHooks = getHooksByEvent(allHooks, 'Stop');
 
-  // ─── Skill Discovery ──────────────────────────────────────────────────────
+  if (preToolUseHooks.length === 0) return null;
+
+  const claudeToolName = mapToolName(payload.tool_name ?? '');
+
+  const matching = preToolUseHooks.filter((h) => {
+    if (!h.toolFilter) return true;
+    return h.toolFilter.includes(claudeToolName);
+  });
+
+  if (matching.length === 0) return null;
+
+  const eventLogger = new BridgeEventLogger(sessionId, directory);
+
+  const results = await executeHooksParallel(matching, [], {
+    cwd: directory,
+    sessionId,
+    eventLogger,
+    hookType: 'PreToolUse',
+  });
+
+  eventLogger.flush();
+
+  return results;
+}
+
+// ─── Event Handlers ─────────────────────────────────────────────────────────
+
+/**
+ * SessionStart: inject Han context and start the coordinator.
+ */
+async function handleSessionStart(
+  _payload: CodexHookPayload,
+  directory: string,
+  sessionId: string
+): Promise<CodexHookOutput> {
+  const resolvedPlugins = resolvePluginPaths(directory);
   const allSkills = discoverAllSkills(resolvedPlugins);
-  const skillsByName = new Map<string, SkillInfo>();
-  for (const skill of allSkills) {
-    skillsByName.set(skill.name, skill);
-  }
-
-  // ─── Discipline Discovery ──────────────────────────────────────────────────
   const allDisciplines = discoverDisciplines(resolvedPlugins, allSkills);
-  const disciplinesByName = new Map<string, DisciplineInfo>();
-  for (const d of allDisciplines) {
-    disciplinesByName.set(d.name, d);
-  }
 
-  // Active discipline for system prompt injection
-  let activeDiscipline: DisciplineInfo | null = null;
-
-  // ─── Logging ──────────────────────────────────────────────────────────────
-
-  const pluginCount = resolvedPlugins.size;
-  const skillCount = allSkills.length;
-  const disciplineCount = allDisciplines.length;
-
-  if (pluginCount === 0) {
+  if (resolvedPlugins.size === 0) {
     console.error(
-      `${PREFIX} No Han plugins found. ` +
-        `Install plugins: han plugin install --auto`
+      `${PREFIX} No Han plugins found. Install plugins: han plugin install --auto`
     );
     return {};
   }
 
-  console.error(
-    `${PREFIX} Discovered ${pluginCount} plugins: ` +
-      `${preToolUseHooks.length} PreToolUse, ` +
-      `${postToolUseHooks.length} PostToolUse, ` +
-      `${stopHooks.length} Stop hooks, ` +
-      `${skillCount} skills, ` +
-      `${disciplineCount} disciplines`
-  );
+  const parts = [buildSessionContext(allSkills.length, allDisciplines.length)];
 
-  // ─── Session State ───────────────────────────────────────────────────────
-  const sessionId = crypto.randomUUID();
-  const pendingValidations = new Map<string, Promise<void>>();
+  // Active discipline via HAN_DISCIPLINE env (set in shell or Codex config)
+  const activeName = process.env.HAN_DISCIPLINE;
+  if (activeName) {
+    const active = allDisciplines.find((d) => d.name === activeName);
+    if (active) {
+      parts.push(buildDisciplineContext(active));
+    } else {
+      console.error(`${PREFIX} HAN_DISCIPLINE="${activeName}" not found`);
+    }
+  }
 
-  // ─── Event Logger ──────────────────────────────────────────────────────
+  // Start coordinator for Browse UI visibility
   const eventLogger = new BridgeEventLogger(sessionId, directory);
-
-  // Set HAN_PROVIDER for child processes (hook commands)
-  process.env.HAN_PROVIDER = 'codex';
-  process.env.HAN_SESSION_ID = sessionId;
-
-  // ─── Coordinator ───────────────────────────────────────────────────────
   startCoordinator(eventLogger.getWatchDir());
 
-  // ─── Plugin Return ─────────────────────────────────────────────────────
-
   return {
-    // ─── Custom Tools ─────────────────────────────────────────────────────
-    // Registered with Codex so the LLM can call them directly.
-
-    tool: {
-      /**
-       * han_skills - Browse and load Han's skill library.
-       *
-       * The LLM calls this to discover available skills and load
-       * their full SKILL.md content when it needs expertise.
-       */
-      han_skills: {
-        description:
-          'Browse and load Han skills (400+ specialized coding skills). ' +
-          'Use action="list" to search available skills, ' +
-          'action="load" with skill name to get full skill content.',
-        parameters: {
-          type: 'object' as const,
-          properties: {
-            action: {
-              type: 'string' as const,
-              enum: ['list', 'load'],
-              description:
-                'Action to perform: "list" to search skills, "load" to get skill content',
-            },
-            skill: {
-              type: 'string' as const,
-              description: 'Skill name to load (required for action=load)',
-            },
-            filter: {
-              type: 'string' as const,
-              description:
-                'Search filter for skill names/descriptions (optional for action=list)',
-            },
-          },
-          required: ['action'],
-        },
-        async execute(args: {
-          action: string;
-          skill?: string;
-          filter?: string;
-        }) {
-          if (args.action === 'load') {
-            if (!args.skill) {
-              return {
-                output: 'Error: skill parameter required for action=load',
-              };
-            }
-
-            const skill = skillsByName.get(args.skill);
-            if (!skill) {
-              // Try partial match
-              const matches = allSkills.filter((s) =>
-                s.name.toLowerCase().includes((args.skill ?? '').toLowerCase())
-              );
-              if (matches.length === 1) {
-                return { output: loadSkillContent(matches[0]) };
-              }
-              if (matches.length > 1) {
-                return {
-                  output:
-                    `Multiple skills match "${args.skill}":\n` +
-                    matches.map((s) => `- ${s.name}`).join('\n') +
-                    '\n\nBe more specific.',
-                };
-              }
-              return {
-                output: `Skill "${args.skill}" not found. Use action="list" to see available skills.`,
-              };
-            }
-
-            return { output: loadSkillContent(skill) };
-          }
-
-          // Default: list
-          return { output: formatSkillList(allSkills, args.filter) };
-        },
-      },
-
-      /**
-       * han_discipline - Activate specialized agent disciplines.
-       *
-       * When activated, the discipline's context is injected into
-       * every subsequent LLM call via system prompt hooks.
-       */
-      han_discipline: {
-        description:
-          'Activate a Han discipline (specialized agent persona). ' +
-          'Use action="list" to see available disciplines, ' +
-          'action="activate" to switch, action="deactivate" to clear.',
-        parameters: {
-          type: 'object' as const,
-          properties: {
-            action: {
-              type: 'string' as const,
-              enum: ['list', 'activate', 'deactivate'],
-              description: 'Action: "list", "activate", or "deactivate"',
-            },
-            discipline: {
-              type: 'string' as const,
-              description: 'Discipline name (required for activate)',
-            },
-          },
-          required: ['action'],
-        },
-        async execute(args: { action: string; discipline?: string }) {
-          if (args.action === 'activate') {
-            if (!args.discipline) {
-              return {
-                output: 'Error: discipline parameter required for activate',
-              };
-            }
-
-            const d = disciplinesByName.get(args.discipline);
-            if (!d) {
-              return {
-                output:
-                  `Discipline "${args.discipline}" not found.\n\n` +
-                  formatDisciplineList(allDisciplines),
-              };
-            }
-
-            activeDiscipline = d;
-            return {
-              output:
-                `Activated discipline: **${d.name}**\n\n` +
-                `${d.description}\n\n` +
-                (d.skills.length > 0
-                  ? `${d.skills.length} specialized skills available. ` +
-                    `Use han_skills to load any of them.`
-                  : ''),
-            };
-          }
-
-          if (args.action === 'deactivate') {
-            const prev = activeDiscipline?.name;
-            activeDiscipline = null;
-            return {
-              output: prev
-                ? `Deactivated discipline: ${prev}`
-                : 'No discipline was active.',
-            };
-          }
-
-          // Default: list
-          return { output: formatDisciplineList(allDisciplines) };
-        },
-      },
-    },
-
-    // ─── System Prompt Injection ─────────────────────────────────────────
-    // Inject core guidelines and active discipline context into every LLM call.
-    // Codex uses config.toml developer_instructions or AGENTS.md for this.
-    // When running as a plugin, we use the system.transform hook if available.
-
-    'experimental.chat.system.transform': async (
-      _input: Record<string, never>,
-      output: { system: string[] }
-    ) => {
-      // Core guidelines (professional honesty, no time estimates, etc.)
-      output.system.push(buildSessionContext(skillCount, disciplineCount));
-
-      // Active discipline context
-      if (activeDiscipline) {
-        output.system.push(buildDisciplineContext(activeDiscipline));
-      }
-    },
-
-    // ─── Chat Message Hook ──────────────────────────────────────────────
-    // Inject datetime on each user message so the LLM knows the current time.
-
-    'chat.message': async (
-      _input: Record<string, unknown>,
-      output: { message: string; parts: unknown[] }
-    ) => {
-      const timeContext = buildPromptContext();
-      output.parts.push({ type: 'text', text: `\n\n${timeContext}` });
-    },
-
-    // ─── Hook Handlers ───────────────────────────────────────────────────
-
-    /**
-     * tool.execute.before → PreToolUse hooks
-     *
-     * Runs before a tool executes. Enables:
-     * - Pre-commit/pre-push validation gates (intercept git commands)
-     * - Input modification (add context to prompts)
-     * - Subagent context injection (discipline context for task tools)
-     */
-    'tool.execute.before': async (
-      input: ToolBeforeInput,
-      output: ToolBeforeOutput
-    ) => {
-      const claudeToolName = mapToolName(input.tool);
-
-      // Inject discipline context into task/agent tool prompts
-      if (activeDiscipline && output.args && typeof output.args === 'object') {
-        const prompt =
-          'prompt' in output.args && typeof output.args.prompt === 'string'
-            ? output.args.prompt
-            : undefined;
-        const message =
-          'message' in output.args && typeof output.args.message === 'string'
-            ? output.args.message
-            : undefined;
-        const target = prompt ?? message;
-
-        if (target && (claudeToolName === 'Task' || input.tool === 'agent')) {
-          const context = buildDisciplineContext(activeDiscipline);
-          const key = prompt ? 'prompt' : 'message';
-          output.args[key] =
-            `<subagent-context>\n${context}\n</subagent-context>\n\n${target}`;
-        }
-      }
-
-      // Run PreToolUse hooks (e.g., pre-commit validation)
-      if (preToolUseHooks.length > 0) {
-        const matching = preToolUseHooks.filter((h) => {
-          if (!h.toolFilter) return true;
-          return h.toolFilter.includes(claudeToolName);
-        });
-
-        if (matching.length > 0) {
-          const results = await executeHooksParallel(matching, [], {
-            cwd: directory,
-            sessionId,
-            eventLogger,
-            hookType: 'PreToolUse',
-          });
-
-          // If any PreToolUse hook fails, log it as a warning in output
-          const failures = results.filter(
-            (r) => !r.skipped && r.exitCode !== 0
-          );
-          if (failures.length > 0) {
-            const warnings = failures
-              .map(
-                (r) =>
-                  `[${r.hook.pluginName}/${r.hook.name}]: ${r.stdout || r.stderr}`
-              )
-              .join('\n');
-            console.error(`${PREFIX} PreToolUse warnings:\n${warnings}`);
-          }
-        }
-      }
-    },
-
-    /**
-     * tool.execute.after → PostToolUse hooks
-     *
-     * This is the PRIMARY validation path. When the agent edits a file,
-     * we run matching validation hooks (biome, eslint, tsc, etc.) as
-     * parallel promises and deliver results as notifications.
-     */
-    'tool.execute.after': async (
-      input: ToolEventInput,
-      output: ToolEventOutput
-    ) => {
-      const claudeToolName = mapToolName(input.tool);
-      const filePaths = extractFilePaths(input, output, directory);
-
-      if (filePaths.length === 0) return;
-
-      // Log file changes and invalidate cache
-      for (const fp of filePaths) {
-        eventLogger.logFileChange(claudeToolName, fp);
-        invalidateFile(fp);
-      }
-
-      // Find hooks matching this tool + file
-      const matching = matchPostToolUseHooks(
-        postToolUseHooks,
-        claudeToolName,
-        filePaths[0],
-        directory
-      );
-
-      if (matching.length === 0) return;
-
-      // Run all matching hooks as parallel promises
-      const validationKey = `${input.callID}-${filePaths.join(',')}`;
-
-      const validationPromise = (async () => {
-        try {
-          const results = await executeHooksParallel(matching, filePaths, {
-            cwd: directory,
-            sessionId,
-            eventLogger,
-            hookType: 'PostToolUse',
-          });
-
-          // Inline feedback: append failures directly to tool output
-          const inline = formatInlineResults(results);
-          if (inline) {
-            output.output += inline;
-          }
-
-          // Async notification: send detailed results as a message
-          const notification = formatNotificationResults(results, filePaths);
-          if (notification) {
-            try {
-              await client.session.prompt({
-                path: { id: input.sessionID },
-                body: {
-                  noReply: true,
-                  parts: [{ type: 'text', text: notification }],
-                },
-              });
-            } catch (err) {
-              // Session may be busy; inline feedback is the fallback
-              console.error(
-                `${PREFIX} Could not send notification:`,
-                err instanceof Error ? err.message : err
-              );
-            }
-          }
-        } catch (err) {
-          console.error(
-            `${PREFIX} PostToolUse hook error:`,
-            err instanceof Error ? err.message : err
-          );
-        } finally {
-          pendingValidations.delete(validationKey);
-        }
-      })();
-
-      pendingValidations.set(validationKey, validationPromise);
-    },
-
-    /**
-     * Generic event handler for session lifecycle events.
-     *
-     * session.idle → Stop hooks (broader project validation)
-     */
-    event: async ({ event }: { event: CodexEvent }) => {
-      if (event.type === 'session.idle') {
-        const rawSessionId = event.properties?.sessionID;
-        const eventSessionId =
-          typeof rawSessionId === 'string' ? rawSessionId : undefined;
-
-        // Wait for any pending PostToolUse validations to finish
-        if (pendingValidations.size > 0) {
-          await Promise.allSettled(pendingValidations.values());
-        }
-
-        // Run Stop hooks for full project validation
-        const matching = matchStopHooks(stopHooks, directory);
-        if (matching.length === 0) return;
-
-        try {
-          const results = await executeHooksParallel(matching, [], {
-            cwd: directory,
-            sessionId,
-            timeout: 120_000, // Stop hooks get more time
-            eventLogger,
-            hookType: 'Stop',
-          });
-
-          const message = formatStopResults(results);
-          if (message && eventSessionId) {
-            await client.session.prompt({
-              path: { id: eventSessionId },
-              body: {
-                parts: [{ type: 'text', text: message }],
-              },
-            });
-          }
-        } catch (err) {
-          console.error(
-            `${PREFIX} Stop hook error:`,
-            err instanceof Error ? err.message : err
-          );
-        }
-      }
-    },
-
-    /**
-     * Stop hook - backup validation gate.
-     *
-     * Codex calls this when the agent signals completion.
-     * If Stop hooks find issues, forces the agent to continue.
-     */
-    stop: async (): Promise<StopResult | undefined> => {
-      const matching = matchStopHooks(stopHooks, directory);
-      if (matching.length === 0) return undefined;
-
-      try {
-        const results = await executeHooksParallel(matching, [], {
-          cwd: directory,
-          sessionId,
-          timeout: 120_000,
-          eventLogger,
-          hookType: 'Stop',
-        });
-
-        const message = formatStopResults(results);
-        if (message) {
-          // Flush events before returning so coordinator has latest data
-          eventLogger.flush();
-          return {
-            continue: true,
-            assistantMessage: message,
-          };
-        }
-      } catch (err) {
-        console.error(
-          `${PREFIX} Stop validation error:`,
-          err instanceof Error ? err.message : err
-        );
-      }
-
-      return undefined;
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext: parts.join('\n\n'),
     },
   };
 }
 
-export default hanBridgePlugin;
+/**
+ * UserPromptSubmit: inject current datetime on each prompt.
+ */
+async function handleUserPromptSubmit(
+  _payload: CodexHookPayload,
+  _directory: string,
+  _sessionId: string
+): Promise<CodexHookOutput> {
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'UserPromptSubmit',
+      additionalContext: buildPromptContext(),
+    },
+  };
+}
+
+/**
+ * PreToolUse: deny the tool call when a Han PreToolUse hook fails.
+ */
+async function handlePreToolUse(
+  payload: CodexHookPayload,
+  directory: string,
+  sessionId: string
+): Promise<CodexHookOutput> {
+  const results = await runPreToolHooks(payload, directory, sessionId);
+  if (!results) return {};
+
+  return formatPreToolUseResults(results) ?? {};
+}
+
+/**
+ * PermissionRequest: deny the permission prompt when a Han hook fails.
+ */
+async function handlePermissionRequest(
+  payload: CodexHookPayload,
+  directory: string,
+  sessionId: string
+): Promise<CodexHookOutput> {
+  const results = await runPreToolHooks(payload, directory, sessionId);
+  if (!results) return {};
+
+  return formatPermissionRequestResults(results) ?? {};
+}
+
+/**
+ * PostToolUse: run validation hooks after edits (primary validation path).
+ * Failures replace the tool result with feedback via decision: "block".
+ */
+async function handlePostToolUse(
+  payload: CodexHookPayload,
+  directory: string,
+  sessionId: string
+): Promise<CodexHookOutput> {
+  const allHooks = discoverHooks(directory);
+  const postToolUseHooks = getHooksByEvent(allHooks, 'PostToolUse');
+
+  if (postToolUseHooks.length === 0) return {};
+
+  const claudeToolName = mapToolName(payload.tool_name ?? '');
+  const filePaths = extractFilePaths(payload);
+
+  if (filePaths.length === 0) return {};
+
+  const eventLogger = new BridgeEventLogger(sessionId, directory);
+
+  // Log file changes and invalidate cache
+  for (const fp of filePaths) {
+    eventLogger.logFileChange(claudeToolName, fp);
+    invalidateFile(fp);
+  }
+
+  const matching = matchPostToolUseHooks(
+    postToolUseHooks,
+    claudeToolName,
+    filePaths[0],
+    directory
+  );
+
+  if (matching.length === 0) return {};
+
+  const results = await executeHooksParallel(matching, filePaths, {
+    cwd: directory,
+    sessionId,
+    eventLogger,
+    hookType: 'PostToolUse',
+  });
+
+  eventLogger.flush();
+
+  return formatPostToolUseResults(results) ?? {};
+}
+
+/**
+ * Stop / SubagentStop: full project validation when the agent finishes.
+ * Failures emit decision: "block" so Codex turns the reason into a new
+ * user prompt and the agent keeps working.
+ */
+async function handleStop(
+  _payload: CodexHookPayload,
+  directory: string,
+  sessionId: string
+): Promise<CodexHookOutput> {
+  const allHooks = discoverHooks(directory);
+  const stopHooks = getHooksByEvent(allHooks, 'Stop');
+  const matching = matchStopHooks(stopHooks, directory);
+
+  if (matching.length === 0) return {};
+
+  const eventLogger = new BridgeEventLogger(sessionId, directory);
+
+  const results = await executeHooksParallel(matching, [], {
+    cwd: directory,
+    sessionId,
+    timeout: 120_000,
+    eventLogger,
+    hookType: 'Stop',
+  });
+
+  eventLogger.flush();
+
+  return formatStopResults(results) ?? {};
+}
+
+/**
+ * PreCompact / PostCompact / SubagentStart: no Han hook equivalents.
+ * Events are flushed after each hook execution, so nothing to do.
+ */
+async function handleNoop(): Promise<CodexHookOutput> {
+  return {};
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const event = process.argv[2];
+
+  if (!event) {
+    console.error(`${PREFIX} Usage: codex-plugin-han <event>`);
+    console.error(
+      `${PREFIX} Events: session-start, user-prompt-submit, pre-tool-use, ` +
+        `permission-request, post-tool-use, pre-compact, post-compact, ` +
+        `subagent-start, subagent-stop, stop`
+    );
+    writeOutput({});
+    process.exit(0);
+  }
+
+  // Set provider env for child processes
+  process.env.HAN_PROVIDER = 'codex';
+
+  const payload = await readStdin();
+
+  // Prefer Codex's session id so events group with the Codex session
+  if (!process.env.HAN_SESSION_ID) {
+    process.env.HAN_SESSION_ID = payload.session_id ?? crypto.randomUUID();
+  }
+  const sessionId = process.env.HAN_SESSION_ID;
+
+  const directory = payload.cwd || process.cwd();
+
+  console.error(
+    `${PREFIX} Event: ${event}, tool: ${payload.tool_name ?? '(none)'}`
+  );
+
+  try {
+    let output: CodexHookOutput;
+
+    switch (event) {
+      case 'session-start':
+        output = await handleSessionStart(payload, directory, sessionId);
+        break;
+      case 'user-prompt-submit':
+        output = await handleUserPromptSubmit(payload, directory, sessionId);
+        break;
+      case 'pre-tool-use':
+        output = await handlePreToolUse(payload, directory, sessionId);
+        break;
+      case 'permission-request':
+        output = await handlePermissionRequest(payload, directory, sessionId);
+        break;
+      case 'post-tool-use':
+        output = await handlePostToolUse(payload, directory, sessionId);
+        break;
+      case 'pre-compact':
+      case 'post-compact':
+      case 'subagent-start':
+        output = await handleNoop();
+        break;
+      case 'subagent-stop':
+      case 'stop':
+        output = await handleStop(payload, directory, sessionId);
+        break;
+      default:
+        console.error(`${PREFIX} Unknown event: ${event}`);
+        output = {};
+    }
+
+    writeOutput(output);
+  } catch (err) {
+    console.error(
+      `${PREFIX} Error handling ${event}:`,
+      err instanceof Error ? err.message : err
+    );
+    // Always output valid JSON, even on error
+    writeOutput({});
+  }
+}
+
+main();

--- a/plugins/bridges/codex/src/types.ts
+++ b/plugins/bridges/codex/src/types.ts
@@ -1,75 +1,104 @@
 /**
  * Shared type definitions for the Han-Codex bridge.
+ *
+ * Codex CLI uses Claude-Code-style lifecycle hooks (enabled with
+ * [features] hooks = true in ~/.codex/config.toml). Each hook is a shell
+ * command that receives JSON via stdin and returns JSON via stdout.
+ * See: https://developers.openai.com/codex/hooks
  */
 
-// ─── Codex Plugin Types ─────────────────────────────────────────────────────
+// ─── Codex Hook Payload Types ───────────────────────────────────────────────
 
 /**
- * Codex plugin context provided by the runtime.
- * See: https://developers.openai.com/codex/cli/features/
- *
- * Codex CLI's extension model uses config.toml-based hooks and MCP servers.
- * This plugin can run as:
- *   1. A Codex config hook handler (invoked by Codex lifecycle events)
- *   2. An MCP server (providing tools like han_skills, han_discipline)
- *   3. A standalone bridge (imported as a JS/TS module)
+ * JSON payload passed to Codex hooks via stdin.
+ * Common fields are present on every event; event-specific fields are
+ * marked optional.
  */
-export interface CodexPluginContext {
-  client: CodexClient;
-  project: unknown;
-  directory: string;
-  worktree: string;
+export interface CodexHookPayload {
+  hook_event_name?: string;
+  session_id?: string;
+  transcript_path?: string;
+  cwd?: string;
+  model?: string;
+  permission_mode?: string;
+  turn_id?: string;
+  /** SessionStart: startup | resume | clear | compact */
+  source?: string;
+  /** UserPromptSubmit: the user's prompt text */
+  prompt?: string;
+  /** PreToolUse / PostToolUse / PermissionRequest: tool name */
+  tool_name?: string;
+  /** PreToolUse / PostToolUse: unique tool call id */
+  tool_use_id?: string;
+  /** PreToolUse / PostToolUse / PermissionRequest: tool parameters */
+  tool_input?: Record<string, unknown>;
+  /** PostToolUse: tool result */
+  tool_response?: unknown;
+  /** Stop / SubagentStop: true when already continuing from a stop hook */
+  stop_hook_active?: boolean;
+  /** Stop / SubagentStop: last assistant message text */
+  last_assistant_message?: string;
+  /** PreCompact / PostCompact: manual | auto */
+  trigger?: string;
+  /** SubagentStart / SubagentStop */
+  agent_id?: string;
+  agent_type?: string;
 }
 
-export interface CodexClient {
-  session: {
-    prompt(args: {
-      path: { id: string };
-      body: {
-        noReply?: boolean;
-        parts: Array<{ type: 'text'; text: string }>;
-      };
-    }): Promise<void>;
+// ─── Codex Hook Response Types ──────────────────────────────────────────────
+
+/**
+ * hookSpecificOutput for PreToolUse: allow/deny with optional input rewrite.
+ */
+export interface CodexPreToolUseOutput {
+  hookEventName: 'PreToolUse';
+  permissionDecision: 'allow' | 'deny' | 'ask';
+  permissionDecisionReason?: string;
+  /** Replacement tool input when permissionDecision is "allow" */
+  updatedInput?: Record<string, unknown>;
+}
+
+/**
+ * hookSpecificOutput for PermissionRequest.
+ */
+export interface CodexPermissionRequestOutput {
+  hookEventName: 'PermissionRequest';
+  decision: {
+    behavior: 'allow' | 'deny';
+    message?: string;
   };
 }
 
 /**
- * Codex tool event shape from hook execution.
- * Codex uses function_call / function_call_output response items.
+ * hookSpecificOutput for context-injecting events
+ * (SessionStart, UserPromptSubmit, SubagentStart, PostToolUse).
  */
-export interface ToolBeforeInput {
-  tool: string;
-  sessionID: string;
-  callID: string;
-}
-
-export interface ToolBeforeOutput {
-  args: Record<string, unknown>;
+export interface CodexContextOutput {
+  hookEventName: string;
+  additionalContext: string;
 }
 
 /**
- * Codex tool event shape after execution.
+ * JSON response written to stdout. Must be valid JSON - only JSON
+ * goes to stdout; all logging goes to stderr.
  */
-export interface ToolEventInput {
-  tool: string;
-  sessionID: string;
-  callID: string;
-}
-
-export interface ToolEventOutput {
-  title: string;
-  output: string;
-  metadata?: Record<string, unknown>;
-}
-
-export interface CodexEvent {
-  type: string;
-  properties?: Record<string, unknown>;
-}
-
-export interface StopResult {
-  continue: boolean;
-  assistantMessage?: string;
+export interface CodexHookOutput {
+  /** false stops all processing; takes precedence over decision */
+  continue?: boolean;
+  /** Message shown to the user when continue is false */
+  stopReason?: string;
+  /** Warning message shown to the user */
+  systemMessage?: string;
+  /** true hides the output from the transcript */
+  suppressOutput?: boolean;
+  /** "block" semantics depend on the event (deny tool, feedback, continue) */
+  decision?: 'block';
+  /** Reason paired with decision (shown to the agent) */
+  reason?: string;
+  hookSpecificOutput?:
+    | CodexPreToolUseOutput
+    | CodexPermissionRequestOutput
+    | CodexContextOutput;
 }
 
 // ─── Han Hook Types ──────────────────────────────────────────────────────────
@@ -122,7 +151,6 @@ export interface HookResult {
 
 /**
  * Han provider identifies which AI coding tool is running the session.
- * Defaults to "claude-code" when HAN_PROVIDER is not set.
  */
 export type HanProvider = 'codex' | 'claude-code';
 
@@ -135,26 +163,20 @@ export function getProvider(): HanProvider {
 // ─── Codex → Claude Code Tool Name Mapping ───────────────────────────────────
 
 /**
- * Map Codex tool names to Claude Code tool names.
- * Codex uses snake_case / lowercase; Claude Code uses PascalCase.
+ * Map Codex tool names to Claude Code tool names for Han hook matching.
  *
- * Codex tools (from function_call response items):
- * - shell: Execute shell commands (equivalent to Bash)
- * - write: Write/create files
- * - edit: Edit existing files via patch
- * - read: Read file contents
- * - list: List directory contents (equivalent to Glob)
+ * Codex's edit tool is apply_patch, but hooks also fire with the
+ * Edit/Write aliases for apply_patch operations - those pass through
+ * as-is. MCP tools (mcp__server__tool) also pass through unchanged.
+ * Read-like tools do not fire PostToolUse matchers in practice.
+ *
+ * See: https://developers.openai.com/codex/hooks
  */
 export const TOOL_NAME_MAP: Record<string, string> = {
-  shell: 'Bash',
-  edit: 'Edit',
-  write: 'Write',
-  read: 'Read',
-  list: 'Glob',
   bash: 'Bash',
-  glob: 'Glob',
-  grep: 'Grep',
-  notebook_edit: 'NotebookEdit',
+  shell: 'Bash',
+  apply_patch: 'Edit',
+  spawn_agent: 'Agent',
 };
 
 export function mapToolName(codexTool: string): string {

--- a/plugins/bridges/gemini-cli/CHANGELOG.md
+++ b/plugins/bridges/gemini-cli/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `SessionEnd` hook: runs any SessionEnd Han hooks and flushes the event log
+  on session exit (advisory; Gemini CLI does not wait)
+
+### Fixed
+
+- discover plugins and hooks from current settings formats: read the
+  `enabledPlugins` boolean map (what `han plugin install` writes) in addition
+  to the legacy `plugins` object map
+- resolve marketplace plugin `source` paths relative to the marketplace root
+  (parent of `.claude-plugin/`), matching Claude Code behavior
+- split Claude Code tool-matcher event suffixes (`PostToolUse:Edit|Write`)
+  into the base event plus tool filter so PostToolUse hooks match
+
+### Changed
+
+- AfterTool validation failures now return `decision:"deny"` with the errors
+  as `reason`, which hides the tool result and shows the reason in its place
+  (previously failures were surfaced via `systemMessage` alongside the tool
+  result)
+
 ## [0.1.0] - 2026-03-02
 
 ### Added

--- a/plugins/bridges/gemini-cli/README.md
+++ b/plugins/bridges/gemini-cli/README.md
@@ -15,15 +15,20 @@ Han plugins define validation hooks, specialized skills, and agent disciplines t
 
 | Claude Code Hook | Gemini CLI Equivalent | Status |
 |---|---|---|
-| PostToolUse | `AfterTool` | Implemented |
+| PostToolUse | `AfterTool` | Implemented (failures return `decision:"deny"` with the errors as `reason`, hiding the tool result) |
 | PreToolUse | `BeforeTool` | Implemented |
 | Stop | `AfterAgent` | Implemented |
 | SessionStart | `SessionStart` | Implemented |
+| SessionEnd | `SessionEnd` | Implemented (advisory; runs SessionEnd Han hooks if any, then flushes the event log) |
 | UserPromptSubmit | `BeforeAgent` | Implemented |
 | PreCompact | `PreCompress` | Implemented |
 | SubagentStart/Stop | — | Not available |
 | Permission denial | `BeforeTool` decision:"deny" | Implemented |
 | MCP tool events | — | Not available |
+| — | `BeforeModel` / `AfterModel` | Intentionally unsupported (Han has no model-level hooks) |
+| — | `BeforeToolSelection` | Intentionally unsupported (Han has no tool-selection hooks) |
+
+Plugin discovery reads the current `enabledPlugins` boolean map (what `han plugin install` writes) as well as the legacy `plugins` object map from Claude Code settings, and resolves marketplace `source` paths relative to the marketplace root.
 
 ## Validation Flow
 
@@ -37,8 +42,8 @@ Agent edits src/app.ts via write_file
   -> Bridge maps write_file -> Write (Claude Code name)
   -> Matches PostToolUse hooks (biome, eslint, tsc)
   -> Runs hooks in parallel
-  -> Returns JSON with systemMessage containing validation errors
-  -> Agent sees errors and fixes them
+  -> On failure: returns decision:"deny" with validation errors as reason
+  -> Tool result is hidden; the agent sees the errors instead and fixes them
 ```
 
 ### AfterAgent (Stop Validation)
@@ -118,10 +123,13 @@ Gemini CLI Hook System
   |     hooks/hooks.json            -> decision:"deny" if validation fails
   |
   |-- AfterTool (matcher: write_file|replace) ──> PostToolUse hooks
-  |     hooks/hooks.json            -> systemMessage with validation errors
+  |     hooks/hooks.json            -> decision:"deny" + reason with validation errors
   |
   |-- AfterAgent ────────────────> Stop hooks (full project validation)
   |     hooks/hooks.json            -> decision:"block" if failures
+  |
+  |-- SessionEnd ────────────────> SessionEnd hooks (if any) + event log flush
+  |     hooks/hooks.json            -> advisory, CLI does not wait
   |
   |-- GEMINI.md ─────────────────> Core guidelines context
   |     (loaded automatically)       (professional honesty, no excuses, etc.)
@@ -171,7 +179,7 @@ Same hook definition. Same validation. Different runtime.
 Gemini CLI hooks communicate via stdin/stdout JSON:
 
 - **Input** (stdin): `{ "tool_name": "write_file", "tool_input": { "path": "src/app.ts", ... } }`
-- **Output** (stdout): `{ "decision": "allow" }` or `{ "systemMessage": "Validation errors..." }`
+- **Output** (stdout): `{ "decision": "allow" }` or `{ "decision": "deny", "reason": "Validation errors..." }`
 - **Logging** (stderr): All debug output goes to stderr (stdout is reserved for JSON)
 
 Exit codes:

--- a/plugins/bridges/gemini-cli/gemini-hooks.json
+++ b/plugins/bridges/gemini-cli/gemini-hooks.json
@@ -72,5 +72,17 @@
         }
       ]
     }
+  ],
+  "SessionEnd": [
+    {
+      "hooks": [
+        {
+          "name": "han-session-end",
+          "type": "command",
+          "command": "bun ${extensionPath}/src/bridge.ts SessionEnd",
+          "timeout": 10000
+        }
+      ]
+    }
   ]
 }

--- a/plugins/bridges/gemini-cli/src/bridge.ts
+++ b/plugins/bridges/gemini-cli/src/bridge.ts
@@ -14,7 +14,8 @@
  *     -> matcher.ts filters by tool name + file pattern
  *     -> executor.ts runs matching hook commands as parallel promises
  *     -> formatter.ts structures results into Gemini CLI JSON response
- *     -> stdout JSON with systemMessage for validation errors
+ *     -> stdout JSON with decision:"deny" + reason for validation errors
+ *        (hides the tool result; reason replaces it per the hook spec)
  *
  *   AfterAgent (agent finished)
  *     -> discovery.ts finds installed plugins' Stop hooks
@@ -33,6 +34,10 @@
  *   BeforeTool
  *     -> Run PreToolUse hooks
  *     -> stdout JSON with decision:"deny" if hook rejects
+ *
+ *   SessionEnd
+ *     -> Run any SessionEnd Han hooks (best-effort)
+ *     -> Flush the event log; advisory, CLI does not wait
  *
  * Key difference from OpenCode bridge: Gemini CLI uses shell command hooks
  * with stdin/stdout JSON protocol, not a JS plugin API. Each hook invocation
@@ -346,6 +351,40 @@ async function handlePreCompress(
   return {};
 }
 
+/**
+ * SessionEnd: Run any SessionEnd Han hooks, then flush the event log.
+ *
+ * Advisory only: Gemini CLI does not wait for SessionEnd hooks, and the
+ * input carries { reason: exit|clear|logout|prompt_input_exit|other }.
+ * Best-effort: if no Han plugin defines SessionEnd hooks this is a no-op
+ * beyond flushing.
+ */
+async function handleSessionEnd(
+  input: GeminiHookInput,
+  projectDir: string
+): Promise<GeminiHookOutput> {
+  console.error(`${PREFIX} SessionEnd (reason: ${input.reason ?? 'unknown'})`);
+
+  const allHooks = discoverHooks(projectDir);
+  const sessionEndHooks = getHooksByEvent(allHooks, 'SessionEnd');
+
+  if (sessionEndHooks.length === 0) return {};
+
+  const sessionId = process.env.GEMINI_SESSION_ID ?? crypto.randomUUID();
+  const eventLogger = new BridgeEventLogger(sessionId, projectDir);
+
+  await executeHooksParallel(sessionEndHooks, [], {
+    cwd: projectDir,
+    sessionId,
+    eventLogger,
+    hookType: 'SessionEnd',
+  });
+
+  eventLogger.flush();
+
+  return {};
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
@@ -354,7 +393,7 @@ async function main(): Promise<void> {
   if (!eventType) {
     console.error(`${PREFIX} Usage: bridge.ts <EventType>`);
     console.error(
-      `${PREFIX} Events: SessionStart, BeforeAgent, BeforeTool, AfterTool, AfterAgent, PreCompress`
+      `${PREFIX} Events: SessionStart, BeforeAgent, BeforeTool, AfterTool, AfterAgent, PreCompress, SessionEnd`
     );
     writeOutput({});
     process.exit(0);
@@ -398,6 +437,9 @@ async function main(): Promise<void> {
         break;
       case 'PreCompress':
         output = await handlePreCompress(input, projectDir);
+        break;
+      case 'SessionEnd':
+        output = await handleSessionEnd(input, projectDir);
         break;
       default:
         console.error(`${PREFIX} Unknown event: ${eventType}`);

--- a/plugins/bridges/gemini-cli/src/discovery.ts
+++ b/plugins/bridges/gemini-cli/src/discovery.ts
@@ -21,7 +21,10 @@ interface PluginEntry {
 }
 
 interface ClaudeSettings {
+  /** Legacy map: { "biome@han": { "enabled": true } } */
   plugins?: Record<string, PluginEntry>;
+  /** Current Claude Code map: { "biome@han": true } */
+  enabledPlugins?: Record<string, boolean>;
 }
 
 interface MarketplacePlugin {
@@ -50,13 +53,23 @@ function getEnabledPlugins(projectDir: string): string[] {
     try {
       const content = readFileSync(path, 'utf-8');
       const settings: ClaudeSettings = JSON.parse(content);
-      if (!settings.plugins) continue;
 
-      for (const [name, entry] of Object.entries(settings.plugins)) {
-        if (entry.enabled !== false) {
-          // Strip @han suffix if present: "biome@han" -> "biome"
-          const cleanName = name.replace(/@han$/, '');
-          pluginNames.add(cleanName);
+      // Legacy `plugins` map
+      if (settings.plugins) {
+        for (const [name, entry] of Object.entries(settings.plugins)) {
+          if (entry.enabled !== false) {
+            // Strip @han suffix if present: "biome@han" -> "biome"
+            pluginNames.add(name.replace(/@han$/, ''));
+          }
+        }
+      }
+
+      // Current `enabledPlugins` map (what `han plugin install` writes)
+      if (settings.enabledPlugins) {
+        for (const [name, enabled] of Object.entries(settings.enabledPlugins)) {
+          if (enabled && name.endsWith('@han')) {
+            pluginNames.add(name.replace(/@han$/, ''));
+          }
         }
       }
     } catch {
@@ -114,8 +127,10 @@ function resolvePluginPath(
   const entry = marketplace.plugins.find((p) => p.name === pluginName);
   if (!entry) return null;
 
-  // source is relative to marketplace.json location (e.g. "./plugins/validation/biome")
-  const pluginPath = resolve(marketplaceDir, entry.source);
+  // source is relative to the marketplace root (the parent of .claude-plugin/),
+  // e.g. "./plugins/validation/biome" resolves to <repo>/plugins/validation/biome
+  const marketplaceRoot = dirname(marketplaceDir);
+  const pluginPath = resolve(marketplaceRoot, entry.source);
   return existsSync(pluginPath) ? pluginPath : null;
 }
 
@@ -253,13 +268,30 @@ function parsePluginHooks(
     for (const [name, def] of Object.entries(config.hooks)) {
       if (!def.command) continue;
 
+      // Events can carry Claude Code tool matchers: "PostToolUse:Edit|Write".
+      // Split the suffix off so the base event matches and the tools act as
+      // the hook's tool filter.
+      const rawEvents = def.event ?? 'Stop'; // Default event is Stop
+      const events = Array.isArray(rawEvents) ? rawEvents : [rawEvents];
+      const baseEvents: string[] = [];
+      const suffixTools: string[] = [];
+      for (const e of events) {
+        const [base, tools] = e.split(':', 2);
+        baseEvents.push(base);
+        if (tools) {
+          suffixTools.push(...tools.split('|').map((t) => t.trim()));
+        }
+      }
+
+      const toolFilter = [...(def.tool_filter ?? []), ...suffixTools];
+
       hooks.push({
         name,
         pluginName,
         pluginRoot,
-        event: def.event ?? 'Stop', // Default event is Stop
+        event: Array.isArray(rawEvents) ? baseEvents : baseEvents[0],
         command: def.command,
-        toolFilter: def.tool_filter,
+        toolFilter: toolFilter.length > 0 ? toolFilter : undefined,
         fileFilter: def.file_filter,
         dirsWith: def.dirs_with,
         dirTest: def.dir_test,

--- a/plugins/bridges/gemini-cli/src/formatter.ts
+++ b/plugins/bridges/gemini-cli/src/formatter.ts
@@ -25,7 +25,10 @@ function formatSingleResult(result: HookResult): string {
 /**
  * Format PostToolUse (AfterTool) hook results for Gemini CLI.
  *
- * Returns a GeminiHookOutput with validation results as systemMessage.
+ * Returns decision: "deny" with the validation output as the reason.
+ * Per the current Gemini CLI hook spec, an AfterTool deny hides the tool
+ * result and the reason replaces it, so the agent sees the validation
+ * failures instead of the (now stale) tool output.
  * If all hooks pass, returns null (empty response).
  */
 export function formatAfterToolResults(
@@ -38,7 +41,7 @@ export function formatAfterToolResults(
   const blocks = failures.map(formatSingleResult).filter(Boolean);
   if (blocks.length === 0) return null;
 
-  const message = [
+  const reason = [
     'Han validation hooks found issues after your last edit.',
     'Please fix these issues before continuing:',
     '',
@@ -46,7 +49,8 @@ export function formatAfterToolResults(
   ].join('\n');
 
   return {
-    systemMessage: message,
+    decision: 'deny',
+    reason,
   };
 }
 

--- a/plugins/bridges/gemini-cli/src/types.ts
+++ b/plugins/bridges/gemini-cli/src/types.ts
@@ -21,6 +21,8 @@ export interface GeminiHookInput {
   llm_response?: unknown;
   /** Final agent response (for AfterAgent hooks) */
   prompt_response?: unknown;
+  /** Exit reason (for SessionEnd hooks): exit|clear|logout|prompt_input_exit|other */
+  reason?: string;
 }
 
 /**

--- a/plugins/bridges/kiro/CHANGELOG.md
+++ b/plugins/bridges/kiro/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- discover plugins and hooks from current settings formats: read the
+  `enabledPlugins` boolean map (what `han plugin install` writes) in addition
+  to the legacy `plugins` object map
+- resolve marketplace plugin `source` paths relative to the marketplace root
+  (parent of `.claude-plugin/`), matching Claude Code behavior
+- split Claude Code tool-matcher event suffixes (`PostToolUse:Edit|Write`)
+  into the base event plus tool filter so PostToolUse hooks match
+
+### Changed
+
+- `stop` hook failures now print `{"decision":"block","reason":"..."}` to
+  stdout and exit 0, so Kiro sends the failure summary to the agent as a new
+  user message and forces it to continue (previously exit 1, a non-blocking
+  warning). Reason is capped at 4000 bytes
+- session IDs for event logging now prefer the `session_id` field Kiro sends
+  on every hook payload, falling back to `HAN_SESSION_ID`
+
 ## [0.1.0] - 2026-02-09
 
 ### Added

--- a/plugins/bridges/kiro/README.md
+++ b/plugins/bridges/kiro/README.md
@@ -10,7 +10,8 @@ Han plugins define validation hooks, specialized skills, and agent disciplines t
 2. **Guidelines** — Core principles (professional honesty, no excuses, skill selection) injected on agent spawn
 3. **Datetime** — Current time injected on every user prompt
 4. **PreToolUse blocking** — Exit code 2 blocks tool execution per Kiro convention
-5. **Events** — Unified JSONL logging with `provider: "kiro"` for Browse UI visibility
+5. **Stop blocking** — Stop failures return `{"decision":"block","reason":"..."}` on stdout, forcing the agent to continue fixing
+6. **Events** — Unified JSONL logging with `provider: "kiro"` for Browse UI visibility
 
 ## Coverage Matrix
 
@@ -18,13 +19,15 @@ Han plugins define validation hooks, specialized skills, and agent disciplines t
 |---|---|---|
 | PostToolUse | `postToolUse` hook | Implemented |
 | PreToolUse | `preToolUse` hook | Implemented |
-| Stop | `stop` hook | Implemented |
+| Stop | `stop` hook | Implemented (blocking via `decision:"block"` JSON on stdout, exit 0) |
 | SessionStart | `agentSpawn` hook | Implemented |
 | UserPromptSubmit | `userPromptSubmit` hook | Implemented |
-| Event Logging | JSONL + coordinator | Implemented |
+| Event Logging | JSONL + coordinator | Implemented (session-correlated via payload `session_id`) |
 | SubagentStart/Stop | — | Not available |
 | MCP tool events | `@mcp/tool` matchers | Partial (Kiro supports MCP matchers) |
 | Permission denial | Exit code 2 | Implemented (Kiro native) |
+
+Plugin discovery reads the current `enabledPlugins` boolean map (what `han plugin install` writes) as well as the legacy `plugins` object map from Claude Code settings, resolves marketplace `source` paths relative to the marketplace root, and understands Claude Code tool-matcher event suffixes (`PostToolUse:Edit|Write`).
 
 ## Key Difference from OpenCode Bridge
 
@@ -76,7 +79,8 @@ When the agent finishes:
 Agent signals completion
   -> Kiro calls: npx kiro-plugin-han stop
   -> Bridge runs Stop hooks (full project lint, typecheck, tests)
-  -> If failures: outputs to stdout, exits 1
+  -> If failures: prints {"decision":"block","reason":"..."} to stdout, exits 0
+  -> Kiro sends the reason to the agent as a new user message
   -> Agent continues to fix project-wide issues
 ```
 
@@ -154,10 +158,12 @@ Kiro uses exit codes for hook communication:
 | Exit Code | Meaning | Used By |
 |-----------|---------|---------|
 | 0 | Success / Allow | All hooks |
-| 1 | Failure (continue with warnings) | stop, postToolUse |
+| 1 | Failure (continue with warnings) | postToolUse |
 | 2 | **Block tool execution** | preToolUse only |
 
 Exit code 2 is Kiro's native blocking mechanism. When a PreToolUse hook exits with code 2, Kiro blocks the tool call and sends stderr to the LLM as the reason.
+
+The `stop` hook is the exception: instead of a non-zero exit code (only a non-blocking warning), the bridge prints a JSON block decision to stdout and exits 0. Kiro reads `{"decision":"block","reason":"..."}` and sends the reason to the agent as a new user message, forcing it to continue. The reason is capped at 4000 bytes.
 
 ## Architecture
 
@@ -185,8 +191,7 @@ Kiro CLI Hook System
   |
   |-- stop ──────────────────────> npx kiro-plugin-han stop
   |     (agent finishes)              -> Run Stop hooks (full project)
-  |                                   -> Validation results to stdout
-  |                                   -> Exit 1 if failures
+  |                                   -> {"decision":"block","reason":...} to stdout, exit 0, if failures
   |
   |-- JSONL logger ──────────────> Event logging
         (hook_run, hook_result)       -> ~/.han/kiro/projects/{slug}/
@@ -240,7 +245,9 @@ Events logged:
 Environment variables set:
 
 - `HAN_PROVIDER=kiro` — Identifies the provider for child processes
-- `HAN_SESSION_ID=<uuid>` — Session ID for event correlation
+- `HAN_SESSION_ID=<uuid>` — Fallback session ID for event correlation
+
+The bridge prefers the `session_id` field Kiro includes in every hook payload, so all events in a session are correlated into one JSONL file. `HAN_SESSION_ID` is only used when the payload has no `session_id`.
 
 ## Remaining Gaps
 

--- a/plugins/bridges/kiro/src/discovery.ts
+++ b/plugins/bridges/kiro/src/discovery.ts
@@ -21,7 +21,10 @@ interface PluginEntry {
 }
 
 interface ClaudeSettings {
+  /** Legacy map: { "biome@han": { "enabled": true } } */
   plugins?: Record<string, PluginEntry>;
+  /** Current Claude Code map: { "biome@han": true } */
+  enabledPlugins?: Record<string, boolean>;
 }
 
 interface MarketplacePlugin {
@@ -50,13 +53,23 @@ function getEnabledPlugins(projectDir: string): string[] {
     try {
       const content = readFileSync(path, 'utf-8');
       const settings: ClaudeSettings = JSON.parse(content);
-      if (!settings.plugins) continue;
 
-      for (const [name, entry] of Object.entries(settings.plugins)) {
-        if (entry.enabled !== false) {
-          // Strip @han suffix if present: "biome@han" -> "biome"
-          const cleanName = name.replace(/@han$/, '');
-          pluginNames.add(cleanName);
+      // Legacy `plugins` map
+      if (settings.plugins) {
+        for (const [name, entry] of Object.entries(settings.plugins)) {
+          if (entry.enabled !== false) {
+            // Strip @han suffix if present: "biome@han" -> "biome"
+            pluginNames.add(name.replace(/@han$/, ''));
+          }
+        }
+      }
+
+      // Current `enabledPlugins` map (what `han plugin install` writes)
+      if (settings.enabledPlugins) {
+        for (const [name, enabled] of Object.entries(settings.enabledPlugins)) {
+          if (enabled && name.endsWith('@han')) {
+            pluginNames.add(name.replace(/@han$/, ''));
+          }
         }
       }
     } catch (err) {
@@ -122,8 +135,10 @@ function resolvePluginPath(
   const entry = marketplace.plugins.find((p) => p.name === pluginName);
   if (!entry) return null;
 
-  // source is relative to marketplace.json location (e.g. "./plugins/validation/biome")
-  const pluginPath = resolve(marketplaceDir, entry.source);
+  // source is relative to the marketplace root (the parent of .claude-plugin/),
+  // e.g. "./plugins/validation/biome" resolves to <repo>/plugins/validation/biome
+  const marketplaceRoot = dirname(marketplaceDir);
+  const pluginPath = resolve(marketplaceRoot, entry.source);
   return existsSync(pluginPath) ? pluginPath : null;
 }
 
@@ -260,13 +275,30 @@ function parsePluginHooks(
     for (const [name, def] of Object.entries(config.hooks)) {
       if (!def.command) continue;
 
+      // Events can carry Claude Code tool matchers: "PostToolUse:Edit|Write".
+      // Split the suffix off so the base event matches and the tools act as
+      // the hook's tool filter.
+      const rawEvents = def.event ?? 'Stop'; // Default event is Stop
+      const events = Array.isArray(rawEvents) ? rawEvents : [rawEvents];
+      const baseEvents: string[] = [];
+      const suffixTools: string[] = [];
+      for (const e of events) {
+        const [base, tools] = e.split(':', 2);
+        baseEvents.push(base);
+        if (tools) {
+          suffixTools.push(...tools.split('|').map((t) => t.trim()));
+        }
+      }
+
+      const toolFilter = [...(def.tool_filter ?? []), ...suffixTools];
+
       hooks.push({
         name,
         pluginName,
         pluginRoot,
-        event: def.event ?? 'Stop', // Default event is Stop
+        event: Array.isArray(rawEvents) ? baseEvents : baseEvents[0],
         command: def.command,
-        toolFilter: def.tool_filter,
+        toolFilter: toolFilter.length > 0 ? toolFilter : undefined,
         fileFilter: def.file_filter,
         dirsWith: def.dirs_with,
         dirTest: def.dir_test,

--- a/plugins/bridges/kiro/src/formatter.ts
+++ b/plugins/bridges/kiro/src/formatter.ts
@@ -10,6 +10,9 @@
 
 import type { HookResult } from './types';
 
+/** Cap on the block-decision reason sent back to the agent. */
+const MAX_BLOCK_REASON_LENGTH = 4_000;
+
 /**
  * Format a single hook result as a structured validation block.
  */
@@ -97,6 +100,28 @@ export function formatStopResults(results: HookResult[]): string | null {
     ...blocks,
     '</han-validation-summary>',
   ].join('\n');
+}
+
+/**
+ * Format Stop hook results as a Kiro block decision.
+ *
+ * Kiro's `stop` hook supports a JSON decision on stdout with exit 0:
+ * {"decision": "block", "reason": "..."} sends the reason to the agent
+ * as a new user message, forcing it to continue and fix the issues.
+ * This replaces the old exit-code-1 warning, which did not gate stopping.
+ *
+ * @returns JSON string for stdout, or null if all passed
+ */
+export function formatStopBlockDecision(results: HookResult[]): string | null {
+  const message = formatStopResults(results);
+  if (!message) return null;
+
+  const reason =
+    message.length <= MAX_BLOCK_REASON_LENGTH
+      ? message
+      : `${message.slice(0, MAX_BLOCK_REASON_LENGTH)}\n... [truncated, ${message.length - MAX_BLOCK_REASON_LENGTH} more bytes]`;
+
+  return JSON.stringify({ decision: 'block', reason });
 }
 
 /**

--- a/plugins/bridges/kiro/src/index.ts
+++ b/plugins/bridges/kiro/src/index.ts
@@ -18,12 +18,12 @@
  *   user-prompt-submit -> UserPromptSubmit (output datetime to stdout)
  *   pre-tool-use       -> PreToolUse (exit 2 to block, stderr for reason)
  *   post-tool-use      -> PostToolUse (stdout for validation results)
- *   stop               -> Stop (stdout for validation, exit 1 if failures)
+ *   stop               -> Stop (stdout {"decision":"block",...} on failures, exit 0)
  *
  * Architecture:
  *
  *   Kiro fires hook event
- *     -> stdin JSON payload { hook_event_name, cwd, tool_name, tool_input }
+ *     -> stdin JSON payload { hook_event_name, cwd, session_id, tool_name, tool_input }
  *     -> bridge reads payload, maps Kiro tool names to Claude Code names
  *     -> discovery.ts finds installed plugins' hooks
  *     -> matcher.ts filters by tool name + file pattern
@@ -46,13 +46,25 @@ import { executeHooksParallel } from './executor';
 import {
   formatPostToolResults,
   formatPreToolResults,
-  formatStopResults,
+  formatStopBlockDecision,
 } from './formatter';
 import { matchPostToolUseHooks, matchStopHooks } from './matcher';
 import { discoverAllSkills } from './skills';
 import { type KiroHookPayload, mapToolName } from './types';
 
 const PREFIX = '[han]';
+
+/**
+ * Resolve the session ID for event correlation.
+ * Kiro includes a stable session_id on every hook payload; prefer it so all
+ * events in a session land in the same JSONL file. Fall back to the env var
+ * (shared with child processes), then a random UUID.
+ */
+function resolveSessionId(payload: KiroHookPayload): string {
+  return (
+    payload.session_id ?? process.env.HAN_SESSION_ID ?? crypto.randomUUID()
+  );
+}
 
 /**
  * Read JSON payload from stdin.
@@ -186,7 +198,7 @@ async function handlePreToolUse(payload: KiroHookPayload): Promise<void> {
   const kiroToolName = payload.tool_name ?? '';
   const claudeToolName = mapToolName(kiroToolName);
 
-  const sessionId = process.env.HAN_SESSION_ID ?? crypto.randomUUID();
+  const sessionId = resolveSessionId(payload);
   const eventLogger = new BridgeEventLogger(sessionId, directory);
 
   const allHooks = discoverHooks(directory);
@@ -232,7 +244,7 @@ async function handlePostToolUse(payload: KiroHookPayload): Promise<void> {
 
   if (filePaths.length === 0) return;
 
-  const sessionId = process.env.HAN_SESSION_ID ?? crypto.randomUUID();
+  const sessionId = resolveSessionId(payload);
   const eventLogger = new BridgeEventLogger(sessionId, directory);
 
   // Log file changes and invalidate cache
@@ -272,12 +284,14 @@ async function handlePostToolUse(payload: KiroHookPayload): Promise<void> {
 /**
  * Handle stop event (full project validation).
  *
- * Runs Stop hooks for project-wide validation.
- * Non-zero exit code tells Kiro the agent should continue fixing.
+ * Runs Stop hooks for project-wide validation. On failure, prints a Kiro
+ * block decision ({"decision":"block","reason":"..."}) to stdout and exits
+ * 0, which sends the reason to the agent as a new user message and forces
+ * it to continue fixing. (Exit 1 was only a non-blocking warning.)
  */
 async function handleStop(payload: KiroHookPayload): Promise<void> {
   const directory = payload.cwd || process.cwd();
-  const sessionId = process.env.HAN_SESSION_ID ?? crypto.randomUUID();
+  const sessionId = resolveSessionId(payload);
   const eventLogger = new BridgeEventLogger(sessionId, directory);
 
   const allHooks = discoverHooks(directory);
@@ -296,10 +310,9 @@ async function handleStop(payload: KiroHookPayload): Promise<void> {
 
   eventLogger.flush();
 
-  const message = formatStopResults(results);
-  if (message) {
-    process.stdout.write(message);
-    process.exit(1);
+  const decision = formatStopBlockDecision(results);
+  if (decision) {
+    process.stdout.write(decision);
   }
 }
 

--- a/plugins/bridges/kiro/src/types.ts
+++ b/plugins/bridges/kiro/src/types.ts
@@ -15,6 +15,8 @@
 export interface KiroHookPayload {
   hook_event_name: string;
   cwd: string;
+  /** Stable session identifier, present on every event */
+  session_id?: string;
   tool_name?: string;
   tool_input?: Record<string, unknown>;
   tool_response?: Record<string, unknown>;

--- a/plugins/bridges/opencode/dist/index.d.ts
+++ b/plugins/bridges/opencode/dist/index.d.ts
@@ -31,7 +31,7 @@
  * not fire-and-forget. Results are collected, parsed, and delivered
  * as structured messages the agent can act on.
  */
-import { type OpenCodeEvent, type OpenCodePluginContext, type StopResult, type ToolBeforeInput, type ToolBeforeOutput, type ToolEventInput, type ToolEventOutput } from './types';
+import { type OpenCodeEvent, type OpenCodePluginContext, type ToolBeforeInput, type ToolBeforeOutput, type ToolEventInput, type ToolEventOutput } from './types';
 /**
  * Main OpenCode plugin entry point.
  */
@@ -57,18 +57,18 @@ declare function hanBridgePlugin(ctx: OpenCodePluginContext): Promise<{
      */
     'tool.execute.after'?: undefined;
     /**
+     * experimental.session.compacting → PreCompact hooks
+     *
+     * Runs before opencode compacts the session. Han PreCompact hook
+     * output is appended to the compaction prompt as extra context.
+     */
+    'experimental.session.compacting'?: undefined;
+    /**
      * Generic event handler for session lifecycle events.
      *
      * session.idle → Stop hooks (broader project validation)
      */
     event?: undefined;
-    /**
-     * Stop hook - backup validation gate.
-     *
-     * OpenCode calls this when the agent signals completion.
-     * If Stop hooks find issues, forces the agent to continue.
-     */
-    stop?: undefined;
 } | {
     tool: {
         /**
@@ -80,19 +80,19 @@ declare function hanBridgePlugin(ctx: OpenCodePluginContext): Promise<{
         han_skills: {
             description: string;
             parameters: {
-                type: "object";
+                type: 'object';
                 properties: {
                     action: {
-                        type: "string";
+                        type: 'string';
                         enum: string[];
                         description: string;
                     };
                     skill: {
-                        type: "string";
+                        type: 'string';
                         description: string;
                     };
                     filter: {
-                        type: "string";
+                        type: 'string';
                         description: string;
                     };
                 };
@@ -115,15 +115,15 @@ declare function hanBridgePlugin(ctx: OpenCodePluginContext): Promise<{
         han_discipline: {
             description: string;
             parameters: {
-                type: "object";
+                type: 'object';
                 properties: {
                     action: {
-                        type: "string";
+                        type: 'string';
                         enum: string[];
                         description: string;
                     };
                     discipline: {
-                        type: "string";
+                        type: 'string';
                         description: string;
                     };
                 };
@@ -162,6 +162,18 @@ declare function hanBridgePlugin(ctx: OpenCodePluginContext): Promise<{
      */
     'tool.execute.after': (input: ToolEventInput, output: ToolEventOutput) => Promise<void>;
     /**
+     * experimental.session.compacting → PreCompact hooks
+     *
+     * Runs before opencode compacts the session. Han PreCompact hook
+     * output is appended to the compaction prompt as extra context.
+     */
+    'experimental.session.compacting': (_input: {
+        sessionID: string;
+    }, output: {
+        context: string[];
+        prompt?: string;
+    }) => Promise<void>;
+    /**
      * Generic event handler for session lifecycle events.
      *
      * session.idle → Stop hooks (broader project validation)
@@ -169,12 +181,5 @@ declare function hanBridgePlugin(ctx: OpenCodePluginContext): Promise<{
     event: ({ event }: {
         event: OpenCodeEvent;
     }) => Promise<void>;
-    /**
-     * Stop hook - backup validation gate.
-     *
-     * OpenCode calls this when the agent signals completion.
-     * If Stop hooks find issues, forces the agent to continue.
-     */
-    stop: () => Promise<StopResult | undefined>;
 }>;
 export default hanBridgePlugin;

--- a/plugins/bridges/opencode/dist/index.js
+++ b/plugins/bridges/opencode/dist/index.js
@@ -112,6 +112,7 @@ async function hanBridgePlugin(ctx) {
     const postToolUseHooks = getHooksByEvent(allHooks, 'PostToolUse');
     const preToolUseHooks = getHooksByEvent(allHooks, 'PreToolUse');
     const stopHooks = getHooksByEvent(allHooks, 'Stop');
+    const preCompactHooks = getHooksByEvent(allHooks, 'PreCompact');
     // ─── Skill Discovery ──────────────────────────────────────────────────────
     const allSkills = discoverAllSkills(resolvedPlugins);
     const skillsByName = new Map();
@@ -410,6 +411,33 @@ async function hanBridgePlugin(ctx) {
             pendingValidations.set(validationKey, validationPromise);
         },
         /**
+         * experimental.session.compacting → PreCompact hooks
+         *
+         * Runs before opencode compacts the session. Han PreCompact hook
+         * output is appended to the compaction prompt as extra context.
+         */
+        'experimental.session.compacting': async (_input, output) => {
+            if (preCompactHooks.length === 0)
+                return;
+            try {
+                const results = await executeHooksParallel(preCompactHooks, [], {
+                    cwd: directory,
+                    sessionId,
+                    timeout: 30_000,
+                    eventLogger,
+                    hookType: 'PreCompact',
+                });
+                for (const result of results) {
+                    if (!result.skipped && result.exitCode === 0 && result.stdout) {
+                        output.context.push(result.stdout);
+                    }
+                }
+            }
+            catch (err) {
+                console.error(`${PREFIX} PreCompact hook error:`, err instanceof Error ? err.message : err);
+            }
+        },
+        /**
          * Generic event handler for session lifecycle events.
          *
          * session.idle → Stop hooks (broader project validation)
@@ -447,39 +475,6 @@ async function hanBridgePlugin(ctx) {
                     console.error(`${PREFIX} Stop hook error:`, err instanceof Error ? err.message : err);
                 }
             }
-        },
-        /**
-         * Stop hook - backup validation gate.
-         *
-         * OpenCode calls this when the agent signals completion.
-         * If Stop hooks find issues, forces the agent to continue.
-         */
-        stop: async () => {
-            const matching = matchStopHooks(stopHooks, directory);
-            if (matching.length === 0)
-                return undefined;
-            try {
-                const results = await executeHooksParallel(matching, [], {
-                    cwd: directory,
-                    sessionId,
-                    timeout: 120_000,
-                    eventLogger,
-                    hookType: 'Stop',
-                });
-                const message = formatStopResults(results);
-                if (message) {
-                    // Flush events before returning so coordinator has latest data
-                    eventLogger.flush();
-                    return {
-                        continue: true,
-                        assistantMessage: message,
-                    };
-                }
-            }
-            catch (err) {
-                console.error(`${PREFIX} Stop validation error:`, err instanceof Error ? err.message : err);
-            }
-            return undefined;
         },
     };
 }

--- a/plugins/bridges/opencode/dist/types.d.ts
+++ b/plugins/bridges/opencode/dist/types.d.ts
@@ -62,10 +62,6 @@ export interface OpenCodeEvent {
     type: string;
     properties?: Record<string, unknown>;
 }
-export interface StopResult {
-    continue: boolean;
-    assistantMessage?: string;
-}
 /**
  * A hook definition parsed from a plugin's han-plugin.yml.
  */

--- a/plugins/bridges/opencode/src/index.ts
+++ b/plugins/bridges/opencode/src/index.ts
@@ -63,7 +63,6 @@ import {
   mapToolName,
   type OpenCodeEvent,
   type OpenCodePluginContext,
-  type StopResult,
   type ToolBeforeInput,
   type ToolBeforeOutput,
   type ToolEventInput,
@@ -160,6 +159,7 @@ async function hanBridgePlugin(ctx: OpenCodePluginContext) {
   const postToolUseHooks = getHooksByEvent(allHooks, 'PostToolUse');
   const preToolUseHooks = getHooksByEvent(allHooks, 'PreToolUse');
   const stopHooks = getHooksByEvent(allHooks, 'Stop');
+  const preCompactHooks = getHooksByEvent(allHooks, 'PreCompact');
 
   // ─── Skill Discovery ──────────────────────────────────────────────────────
   const allSkills = discoverAllSkills(resolvedPlugins);
@@ -542,6 +542,40 @@ async function hanBridgePlugin(ctx: OpenCodePluginContext) {
     },
 
     /**
+     * experimental.session.compacting → PreCompact hooks
+     *
+     * Runs before opencode compacts the session. Han PreCompact hook
+     * output is appended to the compaction prompt as extra context.
+     */
+    'experimental.session.compacting': async (
+      _input: { sessionID: string },
+      output: { context: string[]; prompt?: string }
+    ) => {
+      if (preCompactHooks.length === 0) return;
+
+      try {
+        const results = await executeHooksParallel(preCompactHooks, [], {
+          cwd: directory,
+          sessionId,
+          timeout: 30_000,
+          eventLogger,
+          hookType: 'PreCompact',
+        });
+
+        for (const result of results) {
+          if (!result.skipped && result.exitCode === 0 && result.stdout) {
+            output.context.push(result.stdout);
+          }
+        }
+      } catch (err) {
+        console.error(
+          `${PREFIX} PreCompact hook error:`,
+          err instanceof Error ? err.message : err
+        );
+      }
+    },
+
+    /**
      * Generic event handler for session lifecycle events.
      *
      * session.idle → Stop hooks (broader project validation)
@@ -586,44 +620,6 @@ async function hanBridgePlugin(ctx: OpenCodePluginContext) {
           );
         }
       }
-    },
-
-    /**
-     * Stop hook - backup validation gate.
-     *
-     * OpenCode calls this when the agent signals completion.
-     * If Stop hooks find issues, forces the agent to continue.
-     */
-    stop: async (): Promise<StopResult | undefined> => {
-      const matching = matchStopHooks(stopHooks, directory);
-      if (matching.length === 0) return undefined;
-
-      try {
-        const results = await executeHooksParallel(matching, [], {
-          cwd: directory,
-          sessionId,
-          timeout: 120_000,
-          eventLogger,
-          hookType: 'Stop',
-        });
-
-        const message = formatStopResults(results);
-        if (message) {
-          // Flush events before returning so coordinator has latest data
-          eventLogger.flush();
-          return {
-            continue: true,
-            assistantMessage: message,
-          };
-        }
-      } catch (err) {
-        console.error(
-          `${PREFIX} Stop validation error:`,
-          err instanceof Error ? err.message : err
-        );
-      }
-
-      return undefined;
     },
   };
 }

--- a/plugins/bridges/opencode/src/types.ts
+++ b/plugins/bridges/opencode/src/types.ts
@@ -67,11 +67,6 @@ export interface OpenCodeEvent {
   properties?: Record<string, unknown>;
 }
 
-export interface StopResult {
-  continue: boolean;
-  assistantMessage?: string;
-}
-
 // ─── Han Hook Types ──────────────────────────────────────────────────────────
 
 /**

--- a/plugins/core/han-plugin.yml
+++ b/plugins/core/han-plugin.yml
@@ -1,5 +1,5 @@
 # core plugin configuration
-# Hooks are defined in .claude-plugin/hooks.json for direct Claude Code integration
+# Hooks are defined in hooks/hooks.json for direct Claude Code integration
 # MCP servers are defined in .mcp.json for direct Claude Code integration
 
 hooks: {}

--- a/plugins/core/hooks/hooks.json
+++ b/plugins/core/hooks/hooks.json
@@ -172,6 +172,17 @@
           }
         ]
       }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/worktree-merge-prompt.sh\"",
+            "timeout": 15
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/core/hooks/worktree-merge-prompt.sh
+++ b/plugins/core/hooks/worktree-merge-prompt.sh
@@ -2,8 +2,11 @@
 # worktree-merge-prompt.sh - SubagentStop hook for discipline agents
 # Detects if running in a worktree with changes and prompts user with merge options.
 #
-# Used by discipline agents via their Stop hook (Claude Code auto-converts
-# Stop → SubagentStop for agents).
+# Registered globally by the core plugin as a SubagentStop hook in
+# hooks/hooks.json. Plugin-shipped agents cannot define their own `hooks:`
+# frontmatter (Claude Code ignores it for security reasons), so the core
+# plugin fires this for every subagent; it no-ops instantly unless the
+# subagent's cwd is inside .claude/worktrees/.
 #
 # Exit 0 = no action needed (not in worktree, or no changes)
 # JSON output with decision: "block" = changes exist, ask user what to do

--- a/plugins/disciplines/accessibility-engineering/agents/accessibility-engineer.md
+++ b/plugins/disciplines/accessibility-engineering/agents/accessibility-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Accessibility Engineer

--- a/plugins/disciplines/accessibility-engineering/agents/assistive-tech-specialist.md
+++ b/plugins/disciplines/accessibility-engineering/agents/assistive-tech-specialist.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Assistive Tech Specialist

--- a/plugins/disciplines/accessibility-engineering/agents/inclusive-design-engineer.md
+++ b/plugins/disciplines/accessibility-engineering/agents/inclusive-design-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: purple
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Inclusive Design Engineer

--- a/plugins/disciplines/api-engineering/agents/api-contract-engineer.md
+++ b/plugins/disciplines/api-engineering/agents/api-contract-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # API Contract Engineer

--- a/plugins/disciplines/api-engineering/agents/api-designer.md
+++ b/plugins/disciplines/api-engineering/agents/api-designer.md
@@ -6,11 +6,6 @@ model: inherit
 color: purple
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # API Designer

--- a/plugins/disciplines/api-engineering/agents/api-gateway-engineer.md
+++ b/plugins/disciplines/api-engineering/agents/api-gateway-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # API Gateway Engineer

--- a/plugins/disciplines/backend-development/agents/api-designer.md
+++ b/plugins/disciplines/backend-development/agents/api-designer.md
@@ -24,11 +24,6 @@ color: purple
 model: inherit
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # API Designer

--- a/plugins/disciplines/backend-development/agents/backend-architect.md
+++ b/plugins/disciplines/backend-development/agents/backend-architect.md
@@ -25,11 +25,6 @@ color: yellow
 model: inherit
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Backend Architect

--- a/plugins/disciplines/blockchain-development/agents/blockchain-engineer.md
+++ b/plugins/disciplines/blockchain-development/agents/blockchain-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Blockchain Engineer

--- a/plugins/disciplines/blockchain-development/agents/smart-contract-engineer.md
+++ b/plugins/disciplines/blockchain-development/agents/smart-contract-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Smart Contract Engineer

--- a/plugins/disciplines/blockchain-development/agents/web3-engineer.md
+++ b/plugins/disciplines/blockchain-development/agents/web3-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Web3 Engineer

--- a/plugins/disciplines/claude-plugin-development/agents/plugin-developer.md
+++ b/plugins/disciplines/claude-plugin-development/agents/plugin-developer.md
@@ -10,11 +10,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Claude Plugin Developer Agent

--- a/plugins/disciplines/compiler-engineering/agents/compiler-engineer.md
+++ b/plugins/disciplines/compiler-engineering/agents/compiler-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Compiler Engineer

--- a/plugins/disciplines/compiler-engineering/agents/language-designer.md
+++ b/plugins/disciplines/compiler-engineering/agents/language-designer.md
@@ -6,11 +6,6 @@ model: inherit
 color: purple
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Language Designer

--- a/plugins/disciplines/compiler-engineering/agents/vm-engineer.md
+++ b/plugins/disciplines/compiler-engineering/agents/vm-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # VM Engineer

--- a/plugins/disciplines/content-creation/agents/blog-writer.md
+++ b/plugins/disciplines/content-creation/agents/blog-writer.md
@@ -3,11 +3,6 @@ name: blog-writer
 description: Use when writing blog posts, articles, or long-form content. Expert at SEO optimization, compelling narratives, and audience-focused content.
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Blog Writer Agent

--- a/plugins/disciplines/content-creation/agents/copywriter.md
+++ b/plugins/disciplines/content-creation/agents/copywriter.md
@@ -3,11 +3,6 @@ name: copywriter
 description: Use when writing marketing copy, landing pages, ad copy, email campaigns, or sales materials. Expert at persuasive writing that converts.
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Copywriter Agent

--- a/plugins/disciplines/content-creation/agents/newsletter-writer.md
+++ b/plugins/disciplines/content-creation/agents/newsletter-writer.md
@@ -3,11 +3,6 @@ name: newsletter-writer
 description: Use when creating email newsletters or subscriber communications. Expert at building relationships, providing value, and driving reader action through compelling storytelling.
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Newsletter Writer Agent

--- a/plugins/disciplines/content-creation/agents/social-media-writer.md
+++ b/plugins/disciplines/content-creation/agents/social-media-writer.md
@@ -3,11 +3,6 @@ name: social-media-writer
 description: Use when creating social media posts, tweets, or platform-specific content. Expert at crafting platform-optimized content that drives engagement and builds community.
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Social Media Writer Agent

--- a/plugins/disciplines/content-creation/agents/technical-writer.md
+++ b/plugins/disciplines/content-creation/agents/technical-writer.md
@@ -3,11 +3,6 @@ name: technical-writer
 description: Use when creating API documentation, user guides, tutorials, or developer documentation. Expert at transforming complex technical concepts into clear, accessible documentation.
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Technical Writer Agent

--- a/plugins/disciplines/data-engineering/agents/data-pipeline-engineer.md
+++ b/plugins/disciplines/data-engineering/agents/data-pipeline-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Data Pipeline Engineer

--- a/plugins/disciplines/data-engineering/agents/data-warehouse-engineer.md
+++ b/plugins/disciplines/data-engineering/agents/data-warehouse-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Data Warehouse Engineer

--- a/plugins/disciplines/data-engineering/agents/streaming-engineer.md
+++ b/plugins/disciplines/data-engineering/agents/streaming-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Streaming Engineer

--- a/plugins/disciplines/database-engineering/agents/database-designer.md
+++ b/plugins/disciplines/database-engineering/agents/database-designer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Database Designer

--- a/plugins/disciplines/database-engineering/agents/database-reliability-engineer.md
+++ b/plugins/disciplines/database-engineering/agents/database-reliability-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Database Reliability Engineer

--- a/plugins/disciplines/database-engineering/agents/query-optimizer.md
+++ b/plugins/disciplines/database-engineering/agents/query-optimizer.md
@@ -6,11 +6,6 @@ model: inherit
 color: yellow
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Query Optimizer

--- a/plugins/disciplines/documentation-engineering/agents/documentation-engineer.md
+++ b/plugins/disciplines/documentation-engineering/agents/documentation-engineer.md
@@ -21,11 +21,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Documentation Engineer

--- a/plugins/disciplines/embedded-development/agents/embedded-engineer.md
+++ b/plugins/disciplines/embedded-development/agents/embedded-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Embedded Engineer

--- a/plugins/disciplines/embedded-development/agents/firmware-engineer.md
+++ b/plugins/disciplines/embedded-development/agents/firmware-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Firmware Engineer

--- a/plugins/disciplines/embedded-development/agents/iot-engineer.md
+++ b/plugins/disciplines/embedded-development/agents/iot-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # IoT Engineer

--- a/plugins/disciplines/frontend-development/agents/presentation-engineer.md
+++ b/plugins/disciplines/frontend-development/agents/presentation-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: purple
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Presentation Engineer

--- a/plugins/disciplines/game-development/agents/game-developer.md
+++ b/plugins/disciplines/game-development/agents/game-developer.md
@@ -6,11 +6,6 @@ description: |
   creative problem-solving.
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Game Developer

--- a/plugins/disciplines/game-development/agents/game-engine-architect.md
+++ b/plugins/disciplines/game-development/agents/game-engine-architect.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Game Engine Architect

--- a/plugins/disciplines/game-development/agents/game-performance-engineer.md
+++ b/plugins/disciplines/game-development/agents/game-performance-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: yellow
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Game Performance Engineer

--- a/plugins/disciplines/game-development/agents/game-tools-engineer.md
+++ b/plugins/disciplines/game-development/agents/game-tools-engineer.md
@@ -5,11 +5,6 @@ description: |
   workflow automation. Expert in tooling that multiplies team productivity.
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Game Tools Engineer

--- a/plugins/disciplines/game-development/agents/gameplay-engineer.md
+++ b/plugins/disciplines/game-development/agents/gameplay-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Gameplay Engineer

--- a/plugins/disciplines/game-development/agents/technical-game-designer.md
+++ b/plugins/disciplines/game-development/agents/technical-game-designer.md
@@ -5,11 +5,6 @@ description: |
   systems, implementing design tools, and translating design visions into technical specifications.
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Technical Game Designer

--- a/plugins/disciplines/graphics-engineering/agents/graphics-engineer.md
+++ b/plugins/disciplines/graphics-engineering/agents/graphics-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Graphics Engineer

--- a/plugins/disciplines/graphics-engineering/agents/shader-engineer.md
+++ b/plugins/disciplines/graphics-engineering/agents/shader-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Shader Engineer

--- a/plugins/disciplines/graphics-engineering/agents/visualization-engineer.md
+++ b/plugins/disciplines/graphics-engineering/agents/visualization-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: purple
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Visualization Engineer

--- a/plugins/disciplines/infrastructure-engineering/agents/devops-engineer.md
+++ b/plugins/disciplines/infrastructure-engineering/agents/devops-engineer.md
@@ -26,11 +26,6 @@ color: yellow
 model: inherit
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # DevOps Engineer

--- a/plugins/disciplines/machine-learning/agents/ml-inference-engineer.md
+++ b/plugins/disciplines/machine-learning/agents/ml-inference-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # ML Inference Engineer

--- a/plugins/disciplines/machine-learning/agents/ml-pipeline-engineer.md
+++ b/plugins/disciplines/machine-learning/agents/ml-pipeline-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # ML Pipeline Engineer

--- a/plugins/disciplines/machine-learning/agents/mlops-engineer.md
+++ b/plugins/disciplines/machine-learning/agents/mlops-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # MLOps Engineer

--- a/plugins/disciplines/mobile-development/agents/ios-developer.md
+++ b/plugins/disciplines/mobile-development/agents/ios-developer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # iOS Developer

--- a/plugins/disciplines/mobile-development/agents/mobile-developer.md
+++ b/plugins/disciplines/mobile-development/agents/mobile-developer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Mobile Developer

--- a/plugins/disciplines/network-engineering/agents/distributed-systems-engineer.md
+++ b/plugins/disciplines/network-engineering/agents/distributed-systems-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Distributed Systems Engineer

--- a/plugins/disciplines/network-engineering/agents/network-protocol-engineer.md
+++ b/plugins/disciplines/network-engineering/agents/network-protocol-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Network Protocol Engineer

--- a/plugins/disciplines/network-engineering/agents/service-mesh-engineer.md
+++ b/plugins/disciplines/network-engineering/agents/service-mesh-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Service Mesh Engineer

--- a/plugins/disciplines/observability-engineering/agents/logging-engineer.md
+++ b/plugins/disciplines/observability-engineering/agents/logging-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: yellow
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Logging Engineer

--- a/plugins/disciplines/observability-engineering/agents/monitoring-engineer.md
+++ b/plugins/disciplines/observability-engineering/agents/monitoring-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: yellow
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Monitoring Engineer

--- a/plugins/disciplines/observability-engineering/agents/observability-engineer.md
+++ b/plugins/disciplines/observability-engineering/agents/observability-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: yellow
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Observability Engineer

--- a/plugins/disciplines/performance-engineering/agents/optimization-engineer.md
+++ b/plugins/disciplines/performance-engineering/agents/optimization-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: yellow
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Optimization Engineer

--- a/plugins/disciplines/performance-engineering/agents/performance-engineer.md
+++ b/plugins/disciplines/performance-engineering/agents/performance-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: yellow
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Performance Engineer

--- a/plugins/disciplines/performance-engineering/agents/scalability-engineer.md
+++ b/plugins/disciplines/performance-engineering/agents/scalability-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: yellow
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Scalability Engineer

--- a/plugins/disciplines/platform-engineering/agents/developer-experience-engineer.md
+++ b/plugins/disciplines/platform-engineering/agents/developer-experience-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: purple
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Developer Experience Engineer

--- a/plugins/disciplines/platform-engineering/agents/infrastructure-engineer.md
+++ b/plugins/disciplines/platform-engineering/agents/infrastructure-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Infrastructure Engineer

--- a/plugins/disciplines/platform-engineering/agents/platform-engineer.md
+++ b/plugins/disciplines/platform-engineering/agents/platform-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: blue
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Platform Engineer

--- a/plugins/disciplines/product-management/agents/the-visionary.md
+++ b/plugins/disciplines/product-management/agents/the-visionary.md
@@ -24,11 +24,6 @@ model: inherit
 color: pink
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Product Visionary

--- a/plugins/disciplines/project-management/agents/flow-coordinator.md
+++ b/plugins/disciplines/project-management/agents/flow-coordinator.md
@@ -6,11 +6,6 @@ model: inherit
 color: green
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 # The Flow Coordinator - The Way of Flow
 

--- a/plugins/disciplines/project-management/agents/technical-coordinator.md
+++ b/plugins/disciplines/project-management/agents/technical-coordinator.md
@@ -25,11 +25,6 @@ model: inherit
 color: pink
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Technical Coordinator

--- a/plugins/disciplines/prompt-engineering/agents/prompt-engineer.md
+++ b/plugins/disciplines/prompt-engineering/agents/prompt-engineer.md
@@ -6,11 +6,6 @@ model: inherit
 color: purple
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Prompt Engineer

--- a/plugins/disciplines/quality-engineering/agents/quality-strategist.md
+++ b/plugins/disciplines/quality-engineering/agents/quality-strategist.md
@@ -25,11 +25,6 @@ color: green
 model: inherit
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Quality Strategist

--- a/plugins/disciplines/quality-engineering/agents/test-architect.md
+++ b/plugins/disciplines/quality-engineering/agents/test-architect.md
@@ -25,11 +25,6 @@ color: green
 model: inherit
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Test Architect

--- a/plugins/disciplines/security-engineering/agents/security-engineer.md
+++ b/plugins/disciplines/security-engineering/agents/security-engineer.md
@@ -24,11 +24,6 @@ color: red
 model: inherit
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Security Engineer

--- a/plugins/disciplines/site-reliability-engineering/agents/site-reliability-engineer.md
+++ b/plugins/disciplines/site-reliability-engineering/agents/site-reliability-engineer.md
@@ -6,11 +6,6 @@ description: |
   distributed systems.
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Site Reliability Engineer

--- a/plugins/disciplines/system-architecture/agents/solution-architect.md
+++ b/plugins/disciplines/system-architecture/agents/solution-architect.md
@@ -27,11 +27,6 @@ model: inherit
 color: teal
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # Solution Architect

--- a/plugins/disciplines/system-architecture/agents/system-architect.md
+++ b/plugins/disciplines/system-architecture/agents/system-architect.md
@@ -27,11 +27,6 @@ model: inherit
 color: purple
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 # System Architect

--- a/plugins/disciplines/voip-engineering/agents/voip-engineer.md
+++ b/plugins/disciplines/voip-engineering/agents/voip-engineer.md
@@ -4,11 +4,6 @@ description: Use when working with VoIP systems, SIP protocol, telecommunication
 model: sonnet
 memory: project
 isolation: worktree
-hooks:
-  Stop:
-    - hooks:
-        - type: command
-          command: bash "${CLAUDE_PLUGIN_ROOT}/../../core/hooks/worktree-merge-prompt.sh"
 ---
 
 You are a VoIP engineering expert specializing in telecommunications and real-time communications systems.

--- a/plugins/languages/crystal/hooks/hooks.json
+++ b/plugins/languages/crystal/hooks/hooks.json
@@ -1,17 +1,5 @@
 {
   "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run crystal format --async",
-            "async": true
-          }
-        ],
-        "matcher": "Edit|Write"
-      }
-    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/languages/elixir/han-plugin.yml
+++ b/plugins/languages/elixir/han-plugin.yml
@@ -13,7 +13,7 @@ hooks:
       - ".formatter.exs"
 
   build:
-    event: [Stop, PostToolUse:Edit|Write]
+    event: Stop
     command: "mix compile --warnings-as-errors"
     dirs_with:
       - "mix.exs"

--- a/plugins/languages/erlang/hooks/hooks.json
+++ b/plugins/languages/erlang/hooks/hooks.json
@@ -1,27 +1,6 @@
 {
   "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run erlang format --async",
-            "async": true
-          }
-        ],
-        "matcher": "Edit|Write"
-      }
-    ],
     "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run erlang format --async",
-            "async": true
-          }
-        ]
-      },
       {
         "hooks": [
           {
@@ -42,15 +21,6 @@
       }
     ],
     "SubagentStop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run erlang format --async",
-            "async": true
-          }
-        ]
-      },
       {
         "hooks": [
           {

--- a/plugins/languages/gleam/hooks/hooks.json
+++ b/plugins/languages/gleam/hooks/hooks.json
@@ -1,17 +1,5 @@
 {
   "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run gleam format --async",
-            "async": true
-          }
-        ],
-        "matcher": "Edit|Write"
-      }
-    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/languages/kotlin/hooks/hooks.json
+++ b/plugins/languages/kotlin/hooks/hooks.json
@@ -1,27 +1,6 @@
 {
   "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run kotlin format --async",
-            "async": true
-          }
-        ],
-        "matcher": "Edit|Write"
-      }
-    ],
     "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run kotlin format --async",
-            "async": true
-          }
-        ]
-      },
       {
         "hooks": [
           {
@@ -33,15 +12,6 @@
       }
     ],
     "SubagentStop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run kotlin format --async",
-            "async": true
-          }
-        ]
-      },
       {
         "hooks": [
           {

--- a/plugins/languages/rust/hooks/hooks.json
+++ b/plugins/languages/rust/hooks/hooks.json
@@ -1,17 +1,5 @@
 {
   "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run rust format --async",
-            "async": true
-          }
-        ],
-        "matcher": "Edit|Write"
-      }
-    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/languages/scala/hooks/hooks.json
+++ b/plugins/languages/scala/hooks/hooks.json
@@ -1,27 +1,6 @@
 {
   "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run scala format --async",
-            "async": true
-          }
-        ],
-        "matcher": "Edit|Write"
-      }
-    ],
     "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run scala format --async",
-            "async": true
-          }
-        ]
-      },
       {
         "hooks": [
           {
@@ -33,15 +12,6 @@
       }
     ],
     "SubagentStop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run scala format --async",
-            "async": true
-          }
-        ]
-      },
       {
         "hooks": [
           {

--- a/plugins/languages/swift/hooks/hooks.json
+++ b/plugins/languages/swift/hooks/hooks.json
@@ -1,27 +1,6 @@
 {
   "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run swift format --async",
-            "async": true
-          }
-        ],
-        "matcher": "Edit|Write"
-      }
-    ],
     "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run swift format --async",
-            "async": true
-          }
-        ]
-      },
       {
         "hooks": [
           {
@@ -33,15 +12,6 @@
       }
     ],
     "SubagentStop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run swift format --async",
-            "async": true
-          }
-        ]
-      },
       {
         "hooks": [
           {

--- a/plugins/tools/yarn/hooks/hooks.json
+++ b/plugins/tools/yarn/hooks/hooks.json
@@ -1,16 +1,5 @@
 {
   "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook reference hooks/yarn-reminder.md --must-read-first \"yarn package manager usage\"",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/validation/ameba/hooks/hooks.json
+++ b/plugins/validation/ameba/hooks/hooks.json
@@ -1,17 +1,5 @@
 {
   "hooks": {
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "han hook run ameba lint --async",
-            "async": true
-          }
-        ],
-        "matcher": "Edit|Write"
-      }
-    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/validation/markdown/hooks/hooks.json
+++ b/plugins/validation/markdown/hooks/hooks.json
@@ -9,7 +9,7 @@
             "async": true
           }
         ],
-        "matcher": "Edit|Write|NotebookEdit"
+        "matcher": "Edit|Write"
       }
     ],
     "Stop": [

--- a/plugins/validation/pylint/hooks/hooks.json
+++ b/plugins/validation/pylint/hooks/hooks.json
@@ -9,7 +9,7 @@
             "async": true
           }
         ],
-        "matcher": "Edit|Write|NotebookEdit"
+        "matcher": "Edit|Write"
       }
     ],
     "Stop": [

--- a/website/content/docs/_nav.json
+++ b/website/content/docs/_nav.json
@@ -1,150 +1,150 @@
 {
-  "sections": [
-    {
-      "title": "Getting Started",
-      "items": [
-        {
-          "title": "Overview",
-          "slug": ""
-        },
-        {
-          "title": "What is Han?",
-          "slug": "getting-started"
-        },
-        {
-          "title": "Plugin Categories",
-          "slug": "plugin-categories"
-        }
-      ]
-    },
-    {
-      "title": "Installation",
-      "items": [
-        {
-          "title": "Installation Methods",
-          "slug": "installation"
-        },
-        {
-          "title": "Installing Plugins",
-          "slug": "installation/plugins"
-        },
-        {
-          "title": "Installation Scopes",
-          "slug": "installation/scopes"
-        },
-        {
-          "title": "Using Han with OpenCode",
-          "slug": "installation/opencode"
-        },
-        {
-          "title": "Using Han with Gemini CLI",
-          "slug": "installation/gemini-cli"
-        },
-        {
-          "title": "Using Han with Antigravity",
-          "slug": "installation/antigravity"
-        },
-        {
-          "title": "Using Han with Codex CLI",
-          "slug": "installation/codex"
-        },
-        {
-          "title": "Using Han with Kiro CLI",
-          "slug": "installation/kiro"
-        }
-      ]
-    },
-    {
-      "title": "Configuration",
-      "items": [
-        {
-          "title": "Configuration",
-          "slug": "configuration"
-        },
-        {
-          "title": "Smart Caching",
-          "slug": "configuration/caching"
-        }
-      ]
-    },
-    {
-      "title": "Features",
-      "items": [
-        {
-          "title": "Hook System",
-          "slug": "features/hooks"
-        },
-        {
-          "title": "Checkpoints",
-          "slug": "features/checkpoints"
-        },
-        {
-          "title": "Project Memory",
-          "slug": "features/memory"
-        },
-        {
-          "title": "MCP Integrations",
-          "slug": "integrations"
-        },
-        {
-          "title": "Local Metrics",
-          "slug": "metrics"
-        },
-        {
-          "title": "OpenTelemetry",
-          "slug": "metrics/opentelemetry"
-        }
-      ]
-    },
-    {
-      "title": "Plugin Development",
-      "items": [
-        {
-          "title": "Development Guide",
-          "slug": "plugin-development"
-        },
-        {
-          "title": "Plugin Types",
-          "slug": "plugin-development/types"
-        },
-        {
-          "title": "Hook Configuration",
-          "slug": "plugin-development/hooks"
-        },
-        {
-          "title": "Skills and Commands",
-          "slug": "plugin-development/skills"
-        },
-        {
-          "title": "Testing Plugins",
-          "slug": "plugin-development/testing"
-        },
-        {
-          "title": "Distribution",
-          "slug": "plugin-development/distribution"
-        }
-      ]
-    },
-    {
-      "title": "CLI Reference",
-      "items": [
-        {
-          "title": "Overview",
-          "slug": "cli"
-        },
-        {
-          "title": "Plugin Commands",
-          "slug": "cli/plugins"
-        },
-        {
-          "title": "Hook Commands",
-          "slug": "cli/hooks"
-        },
-        {
-          "title": "Other Commands",
-          "slug": "cli/other"
-        }
-      ]
-    }
-  ]
+	"sections": [
+		{
+			"title": "Getting Started",
+			"items": [
+				{
+					"title": "Overview",
+					"slug": ""
+				},
+				{
+					"title": "What is Han?",
+					"slug": "getting-started"
+				},
+				{
+					"title": "Plugin Categories",
+					"slug": "plugin-categories"
+				}
+			]
+		},
+		{
+			"title": "Installation",
+			"items": [
+				{
+					"title": "Installation Methods",
+					"slug": "installation"
+				},
+				{
+					"title": "Installing Plugins",
+					"slug": "installation/plugins"
+				},
+				{
+					"title": "Installation Scopes",
+					"slug": "installation/scopes"
+				},
+				{
+					"title": "Using Han with OpenCode",
+					"slug": "installation/opencode"
+				},
+				{
+					"title": "Using Han with Gemini CLI",
+					"slug": "installation/gemini-cli"
+				},
+				{
+					"title": "Using Han with Antigravity",
+					"slug": "installation/antigravity"
+				},
+				{
+					"title": "Using Han with Codex CLI",
+					"slug": "installation/codex"
+				},
+				{
+					"title": "Using Han with Kiro CLI",
+					"slug": "installation/kiro"
+				}
+			]
+		},
+		{
+			"title": "Configuration",
+			"items": [
+				{
+					"title": "Configuration",
+					"slug": "configuration"
+				},
+				{
+					"title": "Smart Caching",
+					"slug": "configuration/caching"
+				}
+			]
+		},
+		{
+			"title": "Features",
+			"items": [
+				{
+					"title": "Hook System",
+					"slug": "features/hooks"
+				},
+				{
+					"title": "Checkpoints",
+					"slug": "features/checkpoints"
+				},
+				{
+					"title": "Project Memory",
+					"slug": "features/memory"
+				},
+				{
+					"title": "MCP Integrations",
+					"slug": "integrations"
+				},
+				{
+					"title": "Local Metrics",
+					"slug": "metrics"
+				},
+				{
+					"title": "OpenTelemetry",
+					"slug": "metrics/opentelemetry"
+				}
+			]
+		},
+		{
+			"title": "Plugin Development",
+			"items": [
+				{
+					"title": "Development Guide",
+					"slug": "plugin-development"
+				},
+				{
+					"title": "Plugin Types",
+					"slug": "plugin-development/types"
+				},
+				{
+					"title": "Hook Configuration",
+					"slug": "plugin-development/hooks"
+				},
+				{
+					"title": "Skills and Commands",
+					"slug": "plugin-development/skills"
+				},
+				{
+					"title": "Testing Plugins",
+					"slug": "plugin-development/testing"
+				},
+				{
+					"title": "Distribution",
+					"slug": "plugin-development/distribution"
+				}
+			]
+		},
+		{
+			"title": "CLI Reference",
+			"items": [
+				{
+					"title": "Overview",
+					"slug": "cli"
+				},
+				{
+					"title": "Plugin Commands",
+					"slug": "cli/plugins"
+				},
+				{
+					"title": "Hook Commands",
+					"slug": "cli/hooks"
+				},
+				{
+					"title": "Other Commands",
+					"slug": "cli/other"
+				}
+			]
+		}
+	]
 }

--- a/website/content/docs/_nav.json
+++ b/website/content/docs/_nav.json
@@ -1,67 +1,150 @@
 {
-	"sections": [
-		{
-			"title": "Getting Started",
-			"items": [
-				{ "title": "Overview", "slug": "" },
-				{ "title": "What is Han?", "slug": "getting-started" },
-				{ "title": "Plugin Categories", "slug": "plugin-categories" }
-			]
-		},
-		{
-			"title": "Installation",
-			"items": [
-				{ "title": "Installation Methods", "slug": "installation" },
-				{ "title": "Installing Plugins", "slug": "installation/plugins" },
-				{ "title": "Installation Scopes", "slug": "installation/scopes" },
-				{ "title": "Using Han with OpenCode", "slug": "installation/opencode" },
-				{
-					"title": "Using Han with Gemini CLI",
-					"slug": "installation/gemini-cli"
-				},
-				{
-					"title": "Using Han with Antigravity",
-					"slug": "installation/antigravity"
-				}
-			]
-		},
-		{
-			"title": "Configuration",
-			"items": [
-				{ "title": "Configuration", "slug": "configuration" },
-				{ "title": "Smart Caching", "slug": "configuration/caching" }
-			]
-		},
-		{
-			"title": "Features",
-			"items": [
-				{ "title": "Hook System", "slug": "features/hooks" },
-				{ "title": "Checkpoints", "slug": "features/checkpoints" },
-				{ "title": "Project Memory", "slug": "features/memory" },
-				{ "title": "MCP Integrations", "slug": "integrations" },
-				{ "title": "Local Metrics", "slug": "metrics" },
-				{ "title": "OpenTelemetry", "slug": "metrics/opentelemetry" }
-			]
-		},
-		{
-			"title": "Plugin Development",
-			"items": [
-				{ "title": "Development Guide", "slug": "plugin-development" },
-				{ "title": "Plugin Types", "slug": "plugin-development/types" },
-				{ "title": "Hook Configuration", "slug": "plugin-development/hooks" },
-				{ "title": "Skills and Commands", "slug": "plugin-development/skills" },
-				{ "title": "Testing Plugins", "slug": "plugin-development/testing" },
-				{ "title": "Distribution", "slug": "plugin-development/distribution" }
-			]
-		},
-		{
-			"title": "CLI Reference",
-			"items": [
-				{ "title": "Overview", "slug": "cli" },
-				{ "title": "Plugin Commands", "slug": "cli/plugins" },
-				{ "title": "Hook Commands", "slug": "cli/hooks" },
-				{ "title": "Other Commands", "slug": "cli/other" }
-			]
-		}
-	]
+  "sections": [
+    {
+      "title": "Getting Started",
+      "items": [
+        {
+          "title": "Overview",
+          "slug": ""
+        },
+        {
+          "title": "What is Han?",
+          "slug": "getting-started"
+        },
+        {
+          "title": "Plugin Categories",
+          "slug": "plugin-categories"
+        }
+      ]
+    },
+    {
+      "title": "Installation",
+      "items": [
+        {
+          "title": "Installation Methods",
+          "slug": "installation"
+        },
+        {
+          "title": "Installing Plugins",
+          "slug": "installation/plugins"
+        },
+        {
+          "title": "Installation Scopes",
+          "slug": "installation/scopes"
+        },
+        {
+          "title": "Using Han with OpenCode",
+          "slug": "installation/opencode"
+        },
+        {
+          "title": "Using Han with Gemini CLI",
+          "slug": "installation/gemini-cli"
+        },
+        {
+          "title": "Using Han with Antigravity",
+          "slug": "installation/antigravity"
+        },
+        {
+          "title": "Using Han with Codex CLI",
+          "slug": "installation/codex"
+        },
+        {
+          "title": "Using Han with Kiro CLI",
+          "slug": "installation/kiro"
+        }
+      ]
+    },
+    {
+      "title": "Configuration",
+      "items": [
+        {
+          "title": "Configuration",
+          "slug": "configuration"
+        },
+        {
+          "title": "Smart Caching",
+          "slug": "configuration/caching"
+        }
+      ]
+    },
+    {
+      "title": "Features",
+      "items": [
+        {
+          "title": "Hook System",
+          "slug": "features/hooks"
+        },
+        {
+          "title": "Checkpoints",
+          "slug": "features/checkpoints"
+        },
+        {
+          "title": "Project Memory",
+          "slug": "features/memory"
+        },
+        {
+          "title": "MCP Integrations",
+          "slug": "integrations"
+        },
+        {
+          "title": "Local Metrics",
+          "slug": "metrics"
+        },
+        {
+          "title": "OpenTelemetry",
+          "slug": "metrics/opentelemetry"
+        }
+      ]
+    },
+    {
+      "title": "Plugin Development",
+      "items": [
+        {
+          "title": "Development Guide",
+          "slug": "plugin-development"
+        },
+        {
+          "title": "Plugin Types",
+          "slug": "plugin-development/types"
+        },
+        {
+          "title": "Hook Configuration",
+          "slug": "plugin-development/hooks"
+        },
+        {
+          "title": "Skills and Commands",
+          "slug": "plugin-development/skills"
+        },
+        {
+          "title": "Testing Plugins",
+          "slug": "plugin-development/testing"
+        },
+        {
+          "title": "Distribution",
+          "slug": "plugin-development/distribution"
+        }
+      ]
+    },
+    {
+      "title": "CLI Reference",
+      "items": [
+        {
+          "title": "Overview",
+          "slug": "cli"
+        },
+        {
+          "title": "Plugin Commands",
+          "slug": "cli/plugins"
+        },
+        {
+          "title": "Hook Commands",
+          "slug": "cli/hooks"
+        },
+        {
+          "title": "Other Commands",
+          "slug": "cli/other"
+        }
+      ]
+    }
+  ]
 }

--- a/website/content/docs/installation/codex.md
+++ b/website/content/docs/installation/codex.md
@@ -1,0 +1,152 @@
+---
+title: "Using Han with Codex CLI"
+description: "How to use Han's validation pipeline, skills, and disciplines with OpenAI Codex CLI via lifecycle hooks."
+---
+
+Han works with [OpenAI Codex CLI](https://developers.openai.com/codex/) through its lifecycle hook system. Codex hooks are shell commands that receive JSON on stdin and return JSON decisions on stdout, the same shape as Claude Code hooks, so Han's validation pipeline runs natively.
+
+## How It Works
+
+The bridge is a CLI (`codex-plugin-han`) that Codex calls once per event:
+
+1. **PreToolUse / PostToolUse / Stop** → **validation gates** (biome, eslint, tsc, etc.)
+2. **SessionStart / UserPromptSubmit** → **context injection** (core guidelines, datetime)
+3. **JSON decisions** → **`permissionDecision: "deny"` and `decision: "block"`** keep the agent in the loop until validation passes
+4. **Event logging** → **Browse UI** (sessions visible alongside Claude Code sessions)
+
+```text
+Agent edits src/app.ts via apply_patch
+  -> Codex calls: npx -y codex-plugin-han post-tool-use
+  -> Bridge maps apply_patch -> Edit, matches PostToolUse hooks
+  -> Runs hooks in parallel
+  -> Any fail: { "decision": "block", "reason": ... }
+     (reason replaces the tool result as agent feedback)
+```
+
+## Setup
+
+### 1. Install Han and plugins
+
+```bash
+curl -fsSL https://han.guru/install.sh | bash
+han plugin install --auto
+```
+
+### 2. Install the bridge
+
+```bash
+han plugin install codex@han
+```
+
+### 3. Enable Codex hooks
+
+Hooks are gated behind a feature flag. Add to `~/.codex/config.toml`:
+
+```toml
+[features]
+hooks = true
+```
+
+### 4. Wire the hook events
+
+Add to `~/.codex/hooks.json` (global) or `<repo>/.codex/hooks.json` (per project). Timeouts are in **seconds**:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han session-start", "timeout": 30 }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han user-prompt-submit", "timeout": 10 }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|apply_patch|Edit|Write|spawn_agent|Agent",
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han pre-tool-use", "timeout": 30 }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han permission-request", "timeout": 15 }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "apply_patch|Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han post-tool-use", "timeout": 120 }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han subagent-stop", "timeout": 180 }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y codex-plugin-han stop", "timeout": 180 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The bridge also supports `PreCompact`, `PostCompact`, and `SubagentStart` if you want those events wired (they are no-ops today). See the [bridge README](https://github.com/thebushidocollective/han/tree/main/plugins/bridges/codex) for the full list.
+
+### 5. Optional: Han MCP server
+
+For Han's MCP tools (memory, codebase analysis), add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.han]
+command = "han"
+args = ["mcp"]
+```
+
+## Coverage Matrix
+
+| Claude Code Hook | Codex Hook | Status |
+|---|---|---|
+| SessionStart | `SessionStart` | Implemented |
+| UserPromptSubmit | `UserPromptSubmit` | Implemented |
+| PreToolUse | `PreToolUse` | Implemented |
+| — | `PermissionRequest` | Implemented (runs PreToolUse hooks) |
+| PostToolUse | `PostToolUse` | Implemented |
+| Stop | `Stop` | Implemented |
+| SubagentStop | `SubagentStop` | Implemented (runs Stop hooks) |
+| SubagentStart | `SubagentStart` | Available (no-op) |
+| PreCompact | `PreCompact` | Available (no-op) |
+| PostCompact | `PostCompact` | Available (no-op) |
+
+## Tool Name Mapping
+
+| Codex Tool | Claude Code Equivalent |
+|---|---|
+| `Bash` | `Bash` |
+| `apply_patch` | `Edit` |
+| `Edit` / `Write` (apply_patch aliases) | passed through as-is |
+| `spawn_agent` | `Agent` |
+| `mcp__server__tool` | passed through as-is |
+
+## Event Logging
+
+The bridge writes Han-format JSONL events to `~/.han/codex/projects/{slug}/{sessionId}-han.jsonl` with `provider: "codex"`, indexed by the Han coordinator and visible in the Browse UI alongside Claude Code, OpenCode, and other provider sessions.

--- a/website/content/docs/installation/gemini-cli.md
+++ b/website/content/docs/installation/gemini-cli.md
@@ -44,11 +44,11 @@ curl -fsSL https://bun.sh/install | bash
 
 ### 3. Install the Gemini CLI extension
 
-Use the install script to set up the extension:
+Use the install script bundled with the plugin to set up the extension:
 
 ```bash
-# If han is installed, find the plugin path
-bash "$(han plugin path gemini-cli)/install.sh"
+# From your Claude Code plugin cache (adjust version path as needed)
+bash ~/.claude/plugins/cache/han/gemini-cli/*/install.sh ~/.claude/plugins/cache/han/gemini-cli/*
 ```
 
 Or install directly from the Han repository:

--- a/website/content/docs/installation/index.md
+++ b/website/content/docs/installation/index.md
@@ -3,7 +3,7 @@ title: "Installation Methods"
 description: "Install Han for Claude Code, OpenCode, or standalone use via curl, Homebrew, or plugin install."
 ---
 
-Han works with Claude Code, OpenCode, and as a standalone CLI. Choose the method that fits your workflow.
+Han works with Claude Code, OpenCode, Gemini CLI, Codex CLI, Kiro CLI, Google Antigravity, and as a standalone CLI. Choose the method that fits your workflow.
 
 ## Quick Install (Recommended)
 
@@ -75,6 +75,24 @@ Han works with [OpenCode](https://opencode.ai) through a bridge plugin that tran
 ```
 
 Your Han validation hooks (biome, eslint, typescript, etc.) now run in OpenCode. See the [full OpenCode guide](/docs/installation/opencode) for details.
+
+## Gemini CLI
+
+Han works with [Gemini CLI](https://github.com/google-gemini/gemini-cli) through a Gemini extension that wires Han's hooks into Gemini's lifecycle events (BeforeTool, AfterTool, AfterAgent, SessionStart, SessionEnd).
+
+See the [full Gemini CLI guide](/docs/installation/gemini-cli) for setup.
+
+## Codex CLI
+
+Han works with [OpenAI Codex CLI](https://developers.openai.com/codex/) through Codex's lifecycle hook system (`[features] hooks = true` plus a `hooks.json` wiring `codex-plugin-han` to PreToolUse, PostToolUse, Stop, and the other Codex events).
+
+See the [full Codex CLI guide](/docs/installation/codex) for setup.
+
+## Kiro CLI
+
+Han works with [Kiro CLI](https://kiro.dev) through a Kiro agent definition that maps Kiro's agent hooks (agentSpawn, userPromptSubmit, preToolUse, postToolUse, stop) to Han's validation pipeline.
+
+See the [full Kiro CLI guide](/docs/installation/kiro) for setup.
 
 ## Antigravity
 

--- a/website/content/docs/plugin-development/hooks.md
+++ b/website/content/docs/plugin-development/hooks.md
@@ -140,23 +140,37 @@ Hooks run at specific points during Claude Code sessions:
 | Event | When | Best For |
 |-------|------|----------|
 | `SessionStart` | Session begins | Initialization |
+| `Setup` | `--init` / `--maintenance` runs | One-time CI/script preparation |
 | `UserPromptSubmit` | Before processing input | Pre-process, inject context |
+| `UserPromptExpansion` | Slash command expands into a prompt | Guard or augment skill invocations |
 | `PreToolUse` | Before tool execution | Input validation |
 | `PermissionRequest` | Permission dialog appears (~2.1.50+) | Audit/auto-approve permissions |
+| `PermissionDenied` | Auto-mode classifier denies a tool call (2.1.89+) | Let the model retry with `{retry: true}` |
 | `PostToolUse` | After tool execution | Result processing |
 | `PostToolUseFailure` | Tool execution fails (~2.1.50+) | Error tracking, recovery |
+| `PostToolBatch` | A parallel batch of tool calls resolves | Batch-level feedback before the next model call |
 | `Stop` | Before response completes | Main validation point |
+| `StopFailure` | Turn ends on API error (2.1.78+) | Notification/logging only |
+| `SubagentStart` | Subagent spawned | Inject context into subagents |
 | `SubagentStop` | Subagent completes | Validate agent work |
-| `Notification` | Notification event | Custom notification handling |
-| `PreCompact` | Before context compaction (~2.1.50+) | Save state before compaction |
-| `SessionEnd` | Session ends | Cleanup |
-| `ConfigChange` | Configuration modified (2.1.49+) | Audit trails, config monitoring |
-| `TeammateIdle` | Teammate goes idle (2.1.33+) | Team coordination |
+| `TaskCreated` | Task created via `TaskCreate` (2.1.84+) | Gate task creation |
 | `TaskCompleted` | Task completed (2.1.33+) | Task tracking, workflows |
+| `TeammateIdle` | Teammate goes idle (2.1.33+) | Team coordination |
+| `Notification` | Notification event | Custom notification handling |
+| `MessageDisplay` | Assistant text is displayed (2.1.152+) | Transform displayed text |
+| `InstructionsLoaded` | CLAUDE.md/rules file loads (2.1.69+) | Observability |
+| `ConfigChange` | Configuration modified (2.1.49+) | Audit trails, config monitoring |
+| `CwdChanged` | Working directory changes (2.1.83+) | Reactive env management (direnv-style) |
+| `FileChanged` | Watched file changes on disk (2.1.83+) | Reactive reloads |
+| `PreCompact` | Before context compaction (~2.1.50+, blocking since 2.1.105) | Save state before compaction |
+| `PostCompact` | After context compaction (2.1.76+) | Post-compaction cleanup |
+| `Elicitation` | MCP server requests user input (2.1.76+) | Auto-answer MCP elicitations |
+| `ElicitationResult` | User responds to an MCP elicitation (2.1.76+) | Override elicitation responses |
 | `WorktreeCreate` | Worktree created (2.1.50+) | Agent isolation tracking, custom VCS |
 | `WorktreeRemove` | Worktree removed (2.1.50+) | Cleanup automation |
+| `SessionEnd` | Session ends | Cleanup |
 
-By default, validation and tool plugin hooks run at `Stop` and `SubagentStop`. Claude Code executes plugin hooks directly - you just define what to run.
+By default, validation and tool plugin hooks run at `Stop` and `SubagentStop`. Claude Code executes plugin hooks directly - you just define what to run. Han's `han-plugin.yml` accepts every event above as of Claude Code 2.1.215.
 
 ### New Hook Events (Claude Code 2.1.33+)
 
@@ -266,6 +280,18 @@ Fired when a worktree is being removed. Receives the `worktree_path` that was or
   "worktree_path": "/project/.claude/worktrees/feature-auth"
 }
 ```
+
+### Hook Handler Types and Advanced Fields (Claude Code 2.1.x)
+
+Generated `hooks/hooks.json` files are always `type: "command"` hooks, but a plugin can also ship a hand-authored `hooks/hooks.json` (like the core plugin does) that uses the full Claude Code hook schema:
+
+- **Handler types**: `command` (shell), `http` (POST the event JSON to a URL), `mcp_tool` (call a tool on a connected MCP server, 2.1.118+), `prompt` (single-turn LLM yes/no evaluation), and `agent` (experimental agentic verifier with tools).
+- **Exec form**: set `args: [...]` to spawn `command` directly without a shell (2.1.139+). Safer for paths with spaces; required if you reference `${user_config.*}` values (2.1.207+).
+- **`if` conditions**: permission-rule syntax filtering at the handler level, e.g. `"if": "Bash(git *)"` (2.1.85+).
+- **`async: true` / `asyncRewake: true`**: run in background; `asyncRewake` wakes Claude with the hook's stderr when it exits 2. Note that decision fields have no effect from async hooks.
+- **Matchers**: `|` separates exact tool names; `,` also works (2.1.191+); anything else is treated as a JavaScript regex. Hyphenated names match exactly (2.1.195+).
+
+Prompt and agent hooks must return `{"ok": true|false, "reason": "..."}`; `ok: false` becomes a `decision: "block"` for the event.
 
 ### Stop/SubagentStop: `last_assistant_message` (2.1.47+)
 
@@ -417,8 +443,9 @@ Hooks have access to these environment variables:
 | Variable | Description |
 |----------|-------------|
 | `CLAUDE_SESSION_ID` | Current session ID |
-| `CLAUDE_PROJECT_ROOT` | Project root directory |
-| `CLAUDE_PLUGIN_ROOT` | Plugin installation directory |
+| `CLAUDE_PROJECT_DIR` | Project root directory |
+| `CLAUDE_PLUGIN_ROOT` | Plugin installation directory (changes on update) |
+| `CLAUDE_PLUGIN_DATA` | Persistent plugin data directory (survives updates, 2.1.78+) |
 | `HAN_SESSION_ID` | Session ID (alias) |
 
 Use plugin root for relative paths:


### PR DESCRIPTION
## Summary

Full review of Han against the current AI coding harness landscape (last repo update was 2026-04-28; Claude Code has since moved from 2.1.63 to 2.1.215, Codex shipped a real lifecycle hook system, and the other harnesses evolved). Findings and fixes:

## Review findings

- **Claude Code**: 14 new hook events since 2.1.63 (Setup, UserPromptExpansion, PermissionDenied, PostToolBatch, MessageDisplay, StopFailure, InstructionsLoaded, CwdChanged, FileChanged, PostCompact, Elicitation, ElicitationResult, TaskCreated, plus SubagentStart docs), new handler types (`http`, `mcp_tool`, `prompt`, `agent`), exec-form `args`, `asyncRewake`, `if` conditions, and a hard rule that **plugin-shipped agents cannot declare `hooks:`, `mcpServers:`, or `permissionMode:`**.
- **All bridges** read a stale settings key (`plugins`) while Han and Claude Code write `enabledPlugins` — discovery found zero plugins. (Fixed for opencode in #99; this PR ports it everywhere else.)
- **Codex bridge was built on the opencode JS plugin API** — Codex has no such API. It could never have worked. Codex GA'd real lifecycle hooks (May 2026) with a Claude-Code-shaped protocol.
- **Kiro** stop hook now supports a JSON block decision; the bridge was using a non-blocking exit code, so failed Stop validation didn't gate stopping.
- **Gemini CLI** AfterTool feedback moved to `decision: "deny"` + reason; SessionEnd event unwired.
- **opencode** current `@opencode-ai/plugin` has no `stop` hook (dead code); gained `experimental.session.compacting`.
- **12 plugins' generated hooks.json were stale** relative to their han-plugin.yml; elixir's build hook declared a PostToolUse event its command can't service (no ${HAN_FILES}).
- **71 plugin agents** declared unsupported frontmatter `hooks:`, silently ignored by current Claude Code.

## Changes

- `feat(cli)`: han-plugin.yml event model + generator support every Claude Code event through 2.1.215; generator no longer silently drops unlisted events; hook entry types cover `http`/`mcp_tool`/`agent` + exec form; PostToolUseFailure treated as tool-use event.
- `fix(core)`: worktree-merge prompt moved from 69 agent frontmatters (unsupported) to a global SubagentStop hook in core's hooks.json.
- `feat(bridge-codex)`: full rewrite as a stdio JSON bridge (`npx -y codex-plugin-han <event>`) for all 10 Codex events, with permissionDecision deny, decision:block continuation, tool-name mapping, coordinator integration, and corrected install docs (`codex@han`).
- `feat(bridge-kiro)`: Stop failures now emit `{"decision":"block","reason":...}` (exit 0) so validation actually gates stopping; session_id payload support.
- `feat(bridge-gemini)`: SessionEnd wiring; AfterTool failures return `decision: "deny"` + reason per current spec.
- `fix(bridge-opencode)`: removed dead `stop` handler; added `experimental.session.compacting` → PreCompact hooks; dist rebuilt.
- `fix(bridges)`: discovery ported to `enabledPlugins` + marketplace-root-relative sources + `Event:Tool|Tool` suffix splitting for kiro, gemini-cli, codex, antigravity (verified: 25 plugins resolve from a live settings layout).
- `chore(cli)`: `@anthropic-ai/sdk` ^0.112.3, `@anthropic-ai/claude-agent-sdk` 0.3.215 (typecheck clean).
- `fix(plugins)`: regenerated 12 stale hooks.json; elixir build hook is Stop-only per documented intent.
- `docs`: hooks reference covers all 29 events with version annotations and advanced fields; new Codex installation guide; Codex and Kiro added to docs nav and installation index (Kiro guide existed but was unlisted); stale `han plugin path` reference fixed.

## Verification

- `bun test`: 2217 tests, 0 fail
- `tsc --noEmit`: clean (packages/han + opencode bridge)
- `han plugin generate-hooks --all --check`: passes
- `han hook dispatch Stop`: passes
- Bridge smoke tests: all Codex events emit valid decision JSON on live payloads; kiro stop emits block decision; gemini SessionEnd executes Han SessionEnd hooks; antigravity resolves 25 plugins from live settings
- Not verifiable locally: behavior inside live Codex/Gemini/Kiro CLI binaries (spec compliance is by construction from documented protocols)