### PR TITLE
fix(ci): use npm trusted publishing (OIDC) for bridge packages

### DIFF
--- a/.github/workflows/publish-bridge-plugins.yml
+++ b/.github/workflows/publish-bridge-plugins.yml
@@ -2,6 +2,12 @@ name: Publish Bridge Plugins
 # Publishes bridge plugin packages (opencode-plugin-han, codex-plugin-han, etc.)
 # to npm when their package.json version has not been published yet.
 # Triggered by pushes to main that touch a bridge, or manually.
+#
+# Auth: npm Trusted Publishing (OIDC). No NPM_TOKEN secret required.
+# Each package must have a trusted publisher configured on npmjs.com:
+#   org/user: thebushidocollective (or package owner's account)
+#   repo:     thebushidocollective/han
+#   workflow: publish-bridge-plugins.yml
 
 on:
   workflow_dispatch:
@@ -20,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # npm provenance
+      id-token: write # required for npm trusted publishing + provenance
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +39,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "24"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Read package metadata
         id: pkg
@@ -74,9 +79,12 @@ jobs:
             npx tsc -p tsconfig.tui.json
           fi
 
+      # npm CLI 11.5.1+ (bundled with Node 24) detects the GitHub Actions
+      # OIDC token and publishes via trusted publishing automatically when
+      # no auth token is configured. Provenance is implied.
       - name: Publish to npm
         if: steps.check.outputs.published == 'false'
         working-directory: plugins/bridges/${{ matrix.bridge }}
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm --version
+          npm publish --access public


### PR DESCRIPTION
## Problem

The first run of `publish-bridge-plugins.yml` failed on every bridge with `ENEEDAUTH`: the `NPM_TOKEN` secret the workflow referenced no longer exists (the CLI release this morning still had it; it was removed/rotated later in the day).

## Fix

Drop the token entirely and use npm trusted publishing:

- Removed `registry-url` + `NODE_AUTH_TOKEN` wiring.
- `id-token: write` was already on the job.
- The npm CLI bundled with Node 24 (11.5.1+) detects the GitHub Actions OIDC token and publishes via trusted publishing automatically; provenance attestation is included.

## One-time setup required (outside this PR)

Each bridge package needs a trusted publisher entry on npmjs.com before its first publish:

1. npmjs.com -> profile -> Trusted Publishing (or the org's settings for scoped names)
2. Add GitHub publisher: org `thebushidocollective`, repo `han`, workflow `publish-bridge-plugins.yml`
3. Repeat per package name: `opencode-plugin-han`, `codex-plugin-han`, `gemini-cli-extension-han`, `kiro-plugin-han`, `antigravity-han-mcp`

New (never-published) package names are supported by the same flow.

## Verification

Cannot be fully verified until the npmjs.com publisher entries exist; the workflow is dispatchable manually, so the loop is: configure on npm -> dispatch -> confirm. Everything else (build steps, version-skip logic) already ran in the previous failed run and behaved as designed.