### PR TITLE
fix(bridges): live-test all five harnesses; fix discovery + 4 integration bugs found

### DIFF
--- a/packages/han/lib/commands/setup/index.ts
+++ b/packages/han/lib/commands/setup/index.ts
@@ -137,7 +137,12 @@ args = ["-y", "@thebushidocollective/han", "mcp"]
           content: JSON.stringify(
             {
               $schema: 'https://opencode.ai/config.json',
-              plugin: ['opencode-plugin-han'],
+              // Loaded from the han marketplace clone (installed by
+              // `han plugin install`). The opencode-plugin-han npm
+              // package is not yet published; see the bridge README.
+              plugin: [
+                `file://${process.env.HOME}/.claude/plugins/marketplaces/han/plugins/bridges/opencode/dist/index.js`,
+              ],
             },
             null,
             2

--- a/plugins/bridges/antigravity/CHANGELOG.md
+++ b/plugins/bridges/antigravity/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- locate the marketplace in installed Claude Code marketplaces (`~/.claude/plugins/marketplaces/`) so discovery works in any project, preferring the marketplace named `han`
+- discover enabled plugins from the current `enabledPlugins` settings map in addition to the legacy `plugins` object
+- resolve marketplace plugin sources relative to the marketplace root
+- split `Event:Tool|Tool` matcher suffixes so PostToolUse hooks match
+
 ## [0.1.0] - 2026-07-19
 
 ### Added
@@ -15,15 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - discover plugins from current settings formats ([06838bf5](../../commit/06838bf5))
 - address code review findings on bridge PR ([15c70449](../../commit/15c70449))
-
-## [Unreleased]
-
-### Fixed
-
-- Discover enabled plugins from the current `enabledPlugins` settings map in
-  addition to the legacy `plugins` object
-- Resolve marketplace plugin sources relative to the marketplace root
-- Split `Event:Tool|Tool` matcher suffixes so PostToolUse hooks match
 
 ## [0.1.0] - 2026-07-15
 

--- a/plugins/bridges/antigravity/src/discovery.ts
+++ b/plugins/bridges/antigravity/src/discovery.ts
@@ -9,7 +9,7 @@
  * and marketplace files since Han plugins are provider-agnostic.
  */
 
-import { readFileSync, existsSync } from "node:fs"
+import { readFileSync, readdirSync, existsSync } from "node:fs"
 import { join, resolve, dirname } from "node:path"
 import { homedir } from "node:os"
 import type { HookDefinition } from "./types"
@@ -33,6 +33,7 @@ interface MarketplacePlugin {
 }
 
 interface Marketplace {
+  name?: string
   plugins: MarketplacePlugin[]
 }
 
@@ -84,20 +85,25 @@ function getEnabledPlugins(projectDir: string): string[] {
 // ─── Marketplace Resolution ──────────────────────────────────────────────────
 
 /**
- * Find the marketplace.json file. Searches up from projectDir to find
- * the han repository root, or falls back to the npm-installed marketplace.
+ * Candidate .claude-plugin dirs that may contain the han marketplace.json.
+ * Besides project-relative and home locations, this includes marketplaces
+ * installed by Claude Code under ~/.claude/plugins/marketplaces/<name>/,
+ * which is where `han plugin install` registers the han marketplace.
  */
-function findMarketplace(projectDir: string): Marketplace | null {
+function marketplaceCandidateDirs(projectDir: string): string[] {
   const candidates = [
-    join(projectDir, ".claude-plugin", "marketplace.json"),
-    join(homedir(), ".claude", "marketplace.json"),
+    join(projectDir, ".claude-plugin"),
+    join(homedir(), ".claude"),
   ]
 
   // Walk up directories looking for .claude-plugin/marketplace.json
   let dir = projectDir
   for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, ".claude-plugin", "marketplace.json")
-    if (existsSync(candidate) && !candidates.includes(candidate)) {
+    const candidate = join(dir, ".claude-plugin")
+    if (
+      existsSync(join(candidate, "marketplace.json")) &&
+      !candidates.includes(candidate)
+    ) {
       candidates.unshift(candidate)
     }
     const parent = dirname(dir)
@@ -105,17 +111,65 @@ function findMarketplace(projectDir: string): Marketplace | null {
     dir = parent
   }
 
-  for (const path of candidates) {
+  // Installed marketplaces: ~/.claude/plugins/marketplaces/<name>/.claude-plugin
+  const installedRoot = join(homedir(), ".claude", "plugins", "marketplaces")
+  if (existsSync(installedRoot)) {
+    try {
+      for (const entry of readdirSync(installedRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue
+        const candidate = join(installedRoot, entry.name, ".claude-plugin")
+        if (existsSync(join(candidate, "marketplace.json"))) {
+          candidates.push(candidate)
+        }
+      }
+    } catch {
+      // Ignore unreadable marketplace directories
+    }
+  }
+
+  return candidates
+}
+
+interface MarketplaceLocation {
+  dir: string
+  marketplace: Marketplace
+}
+
+/**
+ * Locate the han marketplace.json and its directory. Candidates are checked
+ * in order (project walk-up first, then well-known dirs, then installed
+ * marketplaces); a marketplace named "han" always wins over an unnamed or
+ * differently named one.
+ */
+function findMarketplaceLocation(
+  projectDir: string,
+): MarketplaceLocation | null {
+  let fallback: MarketplaceLocation | null = null
+
+  for (const dir of marketplaceCandidateDirs(projectDir)) {
+    const path = join(dir, "marketplace.json")
     if (!existsSync(path)) continue
     try {
-      const content = readFileSync(path, "utf-8")
-      return JSON.parse(content) as Marketplace
+      const marketplace = JSON.parse(readFileSync(path, "utf-8")) as
+        | Marketplace
+        | undefined
+      if (!marketplace || !Array.isArray(marketplace.plugins)) continue
+      if (marketplace.name === "han") return { dir, marketplace }
+      if (!fallback) fallback = { dir, marketplace }
     } catch {
       continue
     }
   }
 
-  return null
+  return fallback
+}
+
+/**
+ * Find the marketplace.json file. Searches up from projectDir to find
+ * the han repository root, then installed marketplaces.
+ */
+function findMarketplace(projectDir: string): Marketplace | null {
+  return findMarketplaceLocation(projectDir)?.marketplace ?? null
 }
 
 /**
@@ -336,26 +390,7 @@ export function resolvePluginPaths(projectDir: string): Map<string, string> {
  * Find the directory containing marketplace.json.
  */
 function findMarketplaceDir(projectDir: string): string | null {
-  const candidates = [
-    join(projectDir, ".claude-plugin"),
-    join(homedir(), ".claude"),
-  ]
-
-  let dir = projectDir
-  for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, ".claude-plugin")
-    if (
-      existsSync(join(candidate, "marketplace.json")) &&
-      !candidates.includes(candidate)
-    ) {
-      candidates.unshift(candidate)
-    }
-    const parent = dirname(dir)
-    if (parent === dir) break
-    dir = parent
-  }
-
-  return candidates.find((d) => existsSync(join(d, "marketplace.json"))) ?? null
+  return findMarketplaceLocation(projectDir)?.dir ?? null
 }
 
 /**

--- a/plugins/bridges/codex/CHANGELOG.md
+++ b/plugins/bridges/codex/CHANGELOG.md
@@ -5,26 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- locate the marketplace in installed Claude Code marketplaces (`~/.claude/plugins/marketplaces/`) so discovery works in any project, preferring the marketplace named `han`
+
 ## [0.1.0] - 2026-07-19
 
 ### Added
 
 - rewrite bridge for Codex CLI lifecycle hooks ([0db61833](../../commit/0db61833))
-
-## [Unreleased]
-
-### Changed
-
-- rewrite the bridge for Codex's real hook system (Claude-Code-style lifecycle hooks behind `[features] hooks = true`), replacing the previous implementation that was modeled on a nonexistent OpenCode-style JS plugin API. The bridge is now a stdio JSON CLI (`npx -y codex-plugin-han <event>`) covering all 10 Codex events: session-start, user-prompt-submit, pre-tool-use, permission-request, post-tool-use, pre-compact, post-compact, subagent-start, subagent-stop, stop
-- PreToolUse failures now deny via `hookSpecificOutput.permissionDecision`, PostToolUse failures feed back via `decision: "block"`, and Stop/SubagentStop failures continue the turn via `decision: "block"`
-- map Codex tool names for Han matching: `apply_patch` -> Edit, `Bash` -> Bash, `spawn_agent` -> Agent, `mcp__*` passthrough; file paths extracted from apply_patch headers
-
-### Fixed
-
-- discovery: read `enabledPlugins` boolean map in addition to the legacy `plugins` map in settings files
-- discovery: resolve marketplace plugin `source` paths relative to the marketplace root (parent of `.claude-plugin/`)
-- discovery: split Claude Code tool-matcher suffixes in event strings (`PostToolUse:Edit|Write`) into base event + tool filter
-- README/plugin metadata: correct install command (`han plugin install codex@han`) and document the real integration (`~/.codex/config.toml` + `~/.codex/hooks.json`)
 
 ## [0.1.0] - 2026-03-02
 

--- a/plugins/bridges/codex/src/discovery.ts
+++ b/plugins/bridges/codex/src/discovery.ts
@@ -9,7 +9,7 @@
  * reads, giving the bridge full control over hook execution.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { HookDefinition } from './types';
@@ -33,6 +33,7 @@ interface MarketplacePlugin {
 }
 
 interface Marketplace {
+  name?: string;
   plugins: MarketplacePlugin[];
 }
 
@@ -83,21 +84,25 @@ function getEnabledPlugins(projectDir: string): string[] {
 // ─── Marketplace Resolution ──────────────────────────────────────────────────
 
 /**
- * Find the marketplace.json file. Searches up from projectDir to find
- * the han repository root, or falls back to the npm-installed marketplace.
+ * Candidate .claude-plugin dirs that may contain the han marketplace.json.
+ * Besides project-relative and home locations, this includes marketplaces
+ * installed by Claude Code under ~/.claude/plugins/marketplaces/<name>/,
+ * which is where `han plugin install` registers the han marketplace.
  */
-function findMarketplace(projectDir: string): Marketplace | null {
-  // Check well-known locations
+function marketplaceCandidateDirs(projectDir: string): string[] {
   const candidates = [
-    join(projectDir, '.claude-plugin', 'marketplace.json'),
-    join(homedir(), '.claude', 'marketplace.json'),
+    join(projectDir, '.claude-plugin'),
+    join(homedir(), '.claude'),
   ];
 
   // Walk up directories looking for .claude-plugin/marketplace.json
   let dir = projectDir;
   for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, '.claude-plugin', 'marketplace.json');
-    if (existsSync(candidate) && !candidates.includes(candidate)) {
+    const candidate = join(dir, '.claude-plugin');
+    if (
+      existsSync(join(candidate, 'marketplace.json')) &&
+      !candidates.includes(candidate)
+    ) {
       candidates.unshift(candidate);
     }
     const parent = dirname(dir);
@@ -105,15 +110,63 @@ function findMarketplace(projectDir: string): Marketplace | null {
     dir = parent;
   }
 
-  for (const path of candidates) {
+  // Installed marketplaces: ~/.claude/plugins/marketplaces/<name>/.claude-plugin
+  const installedRoot = join(homedir(), '.claude', 'plugins', 'marketplaces');
+  if (existsSync(installedRoot)) {
+    try {
+      for (const entry of readdirSync(installedRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const candidate = join(installedRoot, entry.name, '.claude-plugin');
+        if (existsSync(join(candidate, 'marketplace.json'))) {
+          candidates.push(candidate);
+        }
+      }
+    } catch {
+      // Ignore unreadable marketplace directories
+    }
+  }
+
+  return candidates;
+}
+
+interface MarketplaceLocation {
+  dir: string;
+  marketplace: Marketplace;
+}
+
+/**
+ * Locate the han marketplace.json and its directory. Candidates are checked
+ * in order (project walk-up first, then well-known dirs, then installed
+ * marketplaces); a marketplace named "han" always wins over an unnamed or
+ * differently named one.
+ */
+function findMarketplaceLocation(
+  projectDir: string
+): MarketplaceLocation | null {
+  let fallback: MarketplaceLocation | null = null;
+
+  for (const dir of marketplaceCandidateDirs(projectDir)) {
+    const path = join(dir, 'marketplace.json');
     if (!existsSync(path)) continue;
     try {
-      const content = readFileSync(path, 'utf-8');
-      return JSON.parse(content) as Marketplace;
+      const marketplace = JSON.parse(readFileSync(path, 'utf-8')) as
+        | Marketplace
+        | undefined;
+      if (!marketplace || !Array.isArray(marketplace.plugins)) continue;
+      if (marketplace.name === 'han') return { dir, marketplace };
+      if (!fallback) fallback = { dir, marketplace };
     } catch {}
   }
 
-  return null;
+  return fallback;
+}
+
+/**
+ * Find the marketplace.json file. Searches up from projectDir to find
+ * the han repository root, then installed marketplaces.
+ */
+function findMarketplace(projectDir: string): Marketplace | null {
+  return findMarketplaceLocation(projectDir)?.marketplace ?? null;
 }
 
 /**
@@ -339,31 +392,11 @@ export function resolvePluginPaths(projectDir: string): Map<string, string> {
 }
 
 /**
- * Find the directory containing marketplace.json.
+ * Find the directory containing the marketplace.json that findMarketplace
+ * would parse (same candidate order, same validity check).
  */
 function findMarketplaceDir(projectDir: string): string | null {
-  const candidates = [
-    join(projectDir, '.claude-plugin'),
-    join(homedir(), '.claude'),
-  ];
-
-  let dir = projectDir;
-  for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, '.claude-plugin');
-    if (
-      existsSync(join(candidate, 'marketplace.json')) &&
-      !candidates.includes(candidate)
-    ) {
-      candidates.unshift(candidate);
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-
-  return (
-    candidates.find((d) => existsSync(join(d, 'marketplace.json'))) ?? null
-  );
+  return findMarketplaceLocation(projectDir)?.dir ?? null;
 }
 
 /**

--- a/plugins/bridges/gemini-cli/CHANGELOG.md
+++ b/plugins/bridges/gemini-cli/CHANGELOG.md
@@ -5,35 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- wrap `gemini-hooks.json` in a top-level `hooks` object; Gemini CLI 0.51 rejected the bare event map ("'hooks' property must be an object") and the extension loaded with zero hooks
+- locate the marketplace in installed Claude Code marketplaces (`~/.claude/plugins/marketplaces/`) so discovery works in any project
+
 ## [0.1.0] - 2026-07-19
 
 ### Added
 
 - add SessionEnd, deny-based AfterTool feedback ([97d942c4](../../commit/97d942c4))
-
-## [Unreleased]
-
-### Added
-
-- `SessionEnd` hook: runs any SessionEnd Han hooks and flushes the event log
-  on session exit (advisory; Gemini CLI does not wait)
-
-### Fixed
-
-- discover plugins and hooks from current settings formats: read the
-  `enabledPlugins` boolean map (what `han plugin install` writes) in addition
-  to the legacy `plugins` object map
-- resolve marketplace plugin `source` paths relative to the marketplace root
-  (parent of `.claude-plugin/`), matching Claude Code behavior
-- split Claude Code tool-matcher event suffixes (`PostToolUse:Edit|Write`)
-  into the base event plus tool filter so PostToolUse hooks match
-
-### Changed
-
-- AfterTool validation failures now return `decision:"deny"` with the errors
-  as `reason`, which hides the tool result and shows the reason in its place
-  (previously failures were surfaced via `systemMessage` alongside the tool
-  result)
 
 ## [0.1.0] - 2026-03-02
 

--- a/plugins/bridges/gemini-cli/gemini-hooks.json
+++ b/plugins/bridges/gemini-cli/gemini-hooks.json
@@ -1,88 +1,90 @@
 {
-  "SessionStart": [
-    {
-      "hooks": [
-        {
-          "name": "han-session-start",
-          "type": "command",
-          "command": "bun ${extensionPath}/src/bridge.ts SessionStart",
-          "timeout": 15000
-        }
-      ]
-    }
-  ],
-  "BeforeAgent": [
-    {
-      "hooks": [
-        {
-          "name": "han-context",
-          "type": "command",
-          "command": "bun ${extensionPath}/src/bridge.ts BeforeAgent",
-          "timeout": 5000
-        }
-      ]
-    }
-  ],
-  "BeforeTool": [
-    {
-      "matcher": "*",
-      "hooks": [
-        {
-          "name": "han-pre-tool",
-          "type": "command",
-          "command": "bun ${extensionPath}/src/bridge.ts BeforeTool",
-          "timeout": 30000
-        }
-      ]
-    }
-  ],
-  "AfterTool": [
-    {
-      "matcher": "write_file|replace",
-      "hooks": [
-        {
-          "name": "han-post-tool",
-          "type": "command",
-          "command": "bun ${extensionPath}/src/bridge.ts AfterTool",
-          "timeout": 60000
-        }
-      ]
-    }
-  ],
-  "AfterAgent": [
-    {
-      "hooks": [
-        {
-          "name": "han-stop",
-          "type": "command",
-          "command": "bun ${extensionPath}/src/bridge.ts AfterAgent",
-          "timeout": 120000
-        }
-      ]
-    }
-  ],
-  "PreCompress": [
-    {
-      "hooks": [
-        {
-          "name": "han-pre-compress",
-          "type": "command",
-          "command": "bun ${extensionPath}/src/bridge.ts PreCompress",
-          "timeout": 5000
-        }
-      ]
-    }
-  ],
-  "SessionEnd": [
-    {
-      "hooks": [
-        {
-          "name": "han-session-end",
-          "type": "command",
-          "command": "bun ${extensionPath}/src/bridge.ts SessionEnd",
-          "timeout": 10000
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "name": "han-session-start",
+            "type": "command",
+            "command": "bun ${extensionPath}/src/bridge.ts SessionStart",
+            "timeout": 15000
+          }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "hooks": [
+          {
+            "name": "han-context",
+            "type": "command",
+            "command": "bun ${extensionPath}/src/bridge.ts BeforeAgent",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "BeforeTool": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "han-pre-tool",
+            "type": "command",
+            "command": "bun ${extensionPath}/src/bridge.ts BeforeTool",
+            "timeout": 30000
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "write_file|replace",
+        "hooks": [
+          {
+            "name": "han-post-tool",
+            "type": "command",
+            "command": "bun ${extensionPath}/src/bridge.ts AfterTool",
+            "timeout": 60000
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "name": "han-stop",
+            "type": "command",
+            "command": "bun ${extensionPath}/src/bridge.ts AfterAgent",
+            "timeout": 120000
+          }
+        ]
+      }
+    ],
+    "PreCompress": [
+      {
+        "hooks": [
+          {
+            "name": "han-pre-compress",
+            "type": "command",
+            "command": "bun ${extensionPath}/src/bridge.ts PreCompress",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "name": "han-session-end",
+            "type": "command",
+            "command": "bun ${extensionPath}/src/bridge.ts SessionEnd",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/bridges/gemini-cli/src/discovery.ts
+++ b/plugins/bridges/gemini-cli/src/discovery.ts
@@ -9,7 +9,7 @@
  * reads, giving the bridge full control over hook execution.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { HookDefinition } from './types';
@@ -33,6 +33,7 @@ interface MarketplacePlugin {
 }
 
 interface Marketplace {
+  name?: string;
   plugins: MarketplacePlugin[];
 }
 
@@ -83,21 +84,25 @@ function getEnabledPlugins(projectDir: string): string[] {
 // ─── Marketplace Resolution ──────────────────────────────────────────────────
 
 /**
- * Find the marketplace.json file. Searches up from projectDir to find
- * the han repository root, or falls back to the npm-installed marketplace.
+ * Candidate .claude-plugin dirs that may contain the han marketplace.json.
+ * Besides project-relative and home locations, this includes marketplaces
+ * installed by Claude Code under ~/.claude/plugins/marketplaces/<name>/,
+ * which is where `han plugin install` registers the han marketplace.
  */
-function findMarketplace(projectDir: string): Marketplace | null {
-  // Check well-known locations
+function marketplaceCandidateDirs(projectDir: string): string[] {
   const candidates = [
-    join(projectDir, '.claude-plugin', 'marketplace.json'),
-    join(homedir(), '.claude', 'marketplace.json'),
+    join(projectDir, '.claude-plugin'),
+    join(homedir(), '.claude'),
   ];
 
   // Walk up directories looking for .claude-plugin/marketplace.json
   let dir = projectDir;
   for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, '.claude-plugin', 'marketplace.json');
-    if (existsSync(candidate) && !candidates.includes(candidate)) {
+    const candidate = join(dir, '.claude-plugin');
+    if (
+      existsSync(join(candidate, 'marketplace.json')) &&
+      !candidates.includes(candidate)
+    ) {
       candidates.unshift(candidate);
     }
     const parent = dirname(dir);
@@ -105,15 +110,63 @@ function findMarketplace(projectDir: string): Marketplace | null {
     dir = parent;
   }
 
-  for (const path of candidates) {
+  // Installed marketplaces: ~/.claude/plugins/marketplaces/<name>/.claude-plugin
+  const installedRoot = join(homedir(), '.claude', 'plugins', 'marketplaces');
+  if (existsSync(installedRoot)) {
+    try {
+      for (const entry of readdirSync(installedRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const candidate = join(installedRoot, entry.name, '.claude-plugin');
+        if (existsSync(join(candidate, 'marketplace.json'))) {
+          candidates.push(candidate);
+        }
+      }
+    } catch {
+      // Ignore unreadable marketplace directories
+    }
+  }
+
+  return candidates;
+}
+
+interface MarketplaceLocation {
+  dir: string;
+  marketplace: Marketplace;
+}
+
+/**
+ * Locate the han marketplace.json and its directory. Candidates are checked
+ * in order (project walk-up first, then well-known dirs, then installed
+ * marketplaces); a marketplace named "han" always wins over an unnamed or
+ * differently named one.
+ */
+function findMarketplaceLocation(
+  projectDir: string
+): MarketplaceLocation | null {
+  let fallback: MarketplaceLocation | null = null;
+
+  for (const dir of marketplaceCandidateDirs(projectDir)) {
+    const path = join(dir, 'marketplace.json');
     if (!existsSync(path)) continue;
     try {
-      const content = readFileSync(path, 'utf-8');
-      return JSON.parse(content) as Marketplace;
+      const marketplace = JSON.parse(readFileSync(path, 'utf-8')) as
+        | Marketplace
+        | undefined;
+      if (!marketplace || !Array.isArray(marketplace.plugins)) continue;
+      if (marketplace.name === 'han') return { dir, marketplace };
+      if (!fallback) fallback = { dir, marketplace };
     } catch {}
   }
 
-  return null;
+  return fallback;
+}
+
+/**
+ * Find the marketplace.json file. Searches up from projectDir to find
+ * the han repository root, then installed marketplaces.
+ */
+function findMarketplace(projectDir: string): Marketplace | null {
+  return findMarketplaceLocation(projectDir)?.marketplace ?? null;
 }
 
 /**
@@ -337,31 +390,11 @@ export function resolvePluginPaths(projectDir: string): Map<string, string> {
 }
 
 /**
- * Find the directory containing marketplace.json.
+ * Find the directory containing the marketplace.json that findMarketplace
+ * would parse (same candidate order, same validity check).
  */
 function findMarketplaceDir(projectDir: string): string | null {
-  const candidates = [
-    join(projectDir, '.claude-plugin'),
-    join(homedir(), '.claude'),
-  ];
-
-  let dir = projectDir;
-  for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, '.claude-plugin');
-    if (
-      existsSync(join(candidate, 'marketplace.json')) &&
-      !candidates.includes(candidate)
-    ) {
-      candidates.unshift(candidate);
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-
-  return (
-    candidates.find((d) => existsSync(join(d, 'marketplace.json'))) ?? null
-  );
+  return findMarketplaceLocation(projectDir)?.dir ?? null;
 }
 
 /**

--- a/plugins/bridges/kiro/CHANGELOG.md
+++ b/plugins/bridges/kiro/CHANGELOG.md
@@ -5,32 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- add a `tools` list to `kiro-agent.json`; without it the han agent has no tools and the model emits `<fs_write>` as plain text instead of writing files
+- locate the marketplace in installed Claude Code marketplaces (`~/.claude/plugins/marketplaces/`) so discovery works in any project
+
 ## [0.1.0] - 2026-07-19
 
 ### Added
 
 - block stop on validation failure, fix discovery ([0e463d7c](../../commit/0e463d7c))
-
-## [Unreleased]
-
-### Fixed
-
-- discover plugins and hooks from current settings formats: read the
-  `enabledPlugins` boolean map (what `han plugin install` writes) in addition
-  to the legacy `plugins` object map
-- resolve marketplace plugin `source` paths relative to the marketplace root
-  (parent of `.claude-plugin/`), matching Claude Code behavior
-- split Claude Code tool-matcher event suffixes (`PostToolUse:Edit|Write`)
-  into the base event plus tool filter so PostToolUse hooks match
-
-### Changed
-
-- `stop` hook failures now print `{"decision":"block","reason":"..."}` to
-  stdout and exit 0, so Kiro sends the failure summary to the agent as a new
-  user message and forces it to continue (previously exit 1, a non-blocking
-  warning). Reason is capped at 4000 bytes
-- session IDs for event logging now prefer the `session_id` field Kiro sends
-  on every hook payload, falling back to `HAN_SESSION_ID`
 
 ## [0.1.0] - 2026-02-09
 

--- a/plugins/bridges/kiro/README.md
+++ b/plugins/bridges/kiro/README.md
@@ -133,6 +133,16 @@ Then start Kiro with the Han agent:
 kiro-cli chat --agent han
 ```
 
+The shipped agent config declares the built-in tools the agent needs
+(`fs_read`, `fs_write`, `execute_bash`, `glob`, `grep`) — without a
+`tools` list Kiro gives a custom agent no tools at all, and the model
+will print fake `<fs_write>` blocks instead of writing files.
+
+Kiro asks for approval before tool calls by default. To pre-approve the
+file tools, add an `allowedTools` list to the agent config, or run with
+`kiro-cli chat --agent han --trust-all-tools` (sandboxed/disposable
+environments only).
+
 **Option B: Add hooks to existing agent**
 
 Merge the hooks from `kiro-agent.json` into your existing agent configuration.

--- a/plugins/bridges/kiro/kiro-agent.json
+++ b/plugins/bridges/kiro/kiro-agent.json
@@ -34,5 +34,13 @@
         "timeout_ms": 120000
       }
     ]
-  }
+  },
+  "tools": [
+    "fs_read",
+    "fs_write",
+    "execute_bash",
+    "glob",
+    "grep",
+    "@builtin"
+  ]
 }

--- a/plugins/bridges/kiro/src/discovery.ts
+++ b/plugins/bridges/kiro/src/discovery.ts
@@ -9,7 +9,7 @@
  * reads, giving the bridge full control over hook execution.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { HookDefinition } from './types';
@@ -33,6 +33,7 @@ interface MarketplacePlugin {
 }
 
 interface Marketplace {
+  name?: string;
   plugins: MarketplacePlugin[];
 }
 
@@ -86,21 +87,25 @@ function getEnabledPlugins(projectDir: string): string[] {
 // ─── Marketplace Resolution ──────────────────────────────────────────────────
 
 /**
- * Find the marketplace.json file. Searches up from projectDir to find
- * the han repository root, or falls back to the npm-installed marketplace.
+ * Candidate .claude-plugin dirs that may contain the han marketplace.json.
+ * Besides project-relative and home locations, this includes marketplaces
+ * installed by Claude Code under ~/.claude/plugins/marketplaces/<name>/,
+ * which is where `han plugin install` registers the han marketplace.
  */
-function findMarketplace(projectDir: string): Marketplace | null {
-  // Check well-known locations
+function marketplaceCandidateDirs(projectDir: string): string[] {
   const candidates = [
-    join(projectDir, '.claude-plugin', 'marketplace.json'),
-    join(homedir(), '.claude', 'marketplace.json'),
+    join(projectDir, '.claude-plugin'),
+    join(homedir(), '.claude'),
   ];
 
   // Walk up directories looking for .claude-plugin/marketplace.json
   let dir = projectDir;
   for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, '.claude-plugin', 'marketplace.json');
-    if (existsSync(candidate) && !candidates.includes(candidate)) {
+    const candidate = join(dir, '.claude-plugin');
+    if (
+      existsSync(join(candidate, 'marketplace.json')) &&
+      !candidates.includes(candidate)
+    ) {
       candidates.unshift(candidate);
     }
     const parent = dirname(dir);
@@ -108,11 +113,51 @@ function findMarketplace(projectDir: string): Marketplace | null {
     dir = parent;
   }
 
-  for (const path of candidates) {
+  // Installed marketplaces: ~/.claude/plugins/marketplaces/<name>/.claude-plugin
+  const installedRoot = join(homedir(), '.claude', 'plugins', 'marketplaces');
+  if (existsSync(installedRoot)) {
+    try {
+      for (const entry of readdirSync(installedRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const candidate = join(installedRoot, entry.name, '.claude-plugin');
+        if (existsSync(join(candidate, 'marketplace.json'))) {
+          candidates.push(candidate);
+        }
+      }
+    } catch {
+      // Ignore unreadable marketplace directories
+    }
+  }
+
+  return candidates;
+}
+
+interface MarketplaceLocation {
+  dir: string;
+  marketplace: Marketplace;
+}
+
+/**
+ * Locate the han marketplace.json and its directory. Candidates are checked
+ * in order (project walk-up first, then well-known dirs, then installed
+ * marketplaces); a marketplace named "han" always wins over an unnamed or
+ * differently named one.
+ */
+function findMarketplaceLocation(
+  projectDir: string
+): MarketplaceLocation | null {
+  let fallback: MarketplaceLocation | null = null;
+
+  for (const dir of marketplaceCandidateDirs(projectDir)) {
+    const path = join(dir, 'marketplace.json');
     if (!existsSync(path)) continue;
     try {
-      const content = readFileSync(path, 'utf-8');
-      return JSON.parse(content) as Marketplace;
+      const marketplace = JSON.parse(readFileSync(path, 'utf-8')) as
+        | Marketplace
+        | undefined;
+      if (!marketplace || !Array.isArray(marketplace.plugins)) continue;
+      if (marketplace.name === 'han') return { dir, marketplace };
+      if (!fallback) fallback = { dir, marketplace };
     } catch (err) {
       console.error(
         `[han] Warning: could not parse marketplace file ${path}:`,
@@ -121,7 +166,15 @@ function findMarketplace(projectDir: string): Marketplace | null {
     }
   }
 
-  return null;
+  return fallback;
+}
+
+/**
+ * Find the marketplace.json file. Searches up from projectDir to find
+ * the han repository root, then installed marketplaces.
+ */
+function findMarketplace(projectDir: string): Marketplace | null {
+  return findMarketplaceLocation(projectDir)?.marketplace ?? null;
 }
 
 /**
@@ -351,28 +404,7 @@ export function resolvePluginPaths(projectDir: string): Map<string, string> {
  * Find the directory containing marketplace.json.
  */
 function findMarketplaceDir(projectDir: string): string | null {
-  const candidates = [
-    join(projectDir, '.claude-plugin'),
-    join(homedir(), '.claude'),
-  ];
-
-  let dir = projectDir;
-  for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, '.claude-plugin');
-    if (
-      existsSync(join(candidate, 'marketplace.json')) &&
-      !candidates.includes(candidate)
-    ) {
-      candidates.unshift(candidate);
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-
-  return (
-    candidates.find((d) => existsSync(join(d, 'marketplace.json'))) ?? null
-  );
+  return findMarketplaceLocation(projectDir)?.dir ?? null;
 }
 
 /**

--- a/plugins/bridges/opencode/CHANGELOG.md
+++ b/plugins/bridges/opencode/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- locate the marketplace in installed Claude Code marketplaces (`~/.claude/plugins/marketplaces/`) so discovery works in any project, preferring the marketplace named `han`
+- `chat.message` no longer crashes sessions: the datetime context is merged into the user's existing text part instead of pushing a bare part that current opencode rejects (`InvalidDurableEvent`)
+- PostToolUse hooks match again: file paths are read from `input.args.filePath` (previously only output metadata/title, which never matched for write/edit)
+
 ## [0.1.0] - 2026-07-19
 
 ### Fixed

--- a/plugins/bridges/opencode/README.md
+++ b/plugins/bridges/opencode/README.md
@@ -19,7 +19,8 @@ Han plugins define validation hooks, specialized skills, and agent disciplines t
 |---|---|---|
 | PostToolUse | `tool.execute.after` | Implemented |
 | PreToolUse | `tool.execute.before` | Implemented |
-| Stop | `stop` + `session.idle` | Implemented |
+| Stop | `session.idle` | Implemented |
+| PreCompact | `experimental.session.compacting` | Implemented |
 | SessionStart | `experimental.chat.system.transform` | Implemented |
 | UserPromptSubmit | `chat.message` | Implemented |
 | SubagentPrompt | `tool.execute.before` (Task/agent) | Implemented |
@@ -61,8 +62,8 @@ Agent edits src/app.ts via Edit tool
 When the agent finishes a turn:
 
 ```
-Agent signals completion
-  -> OpenCode fires session.idle / stop
+Agent finishes its turn
+  -> OpenCode fires session.idle
   -> Bridge runs Stop hooks (full project lint, typecheck, tests)
   -> If failures: re-prompts agent via client.session.prompt()
   -> Agent gets a new turn to fix project-wide issues
@@ -111,18 +112,22 @@ han plugin install --auto
 
 ### Install the Bridge
 
-**Option A: npm package** (recommended)
-
-Add to your `opencode.json`:
+The bridge is distributed with the han marketplace (installed by
+`han plugin install --auto`). Point opencode at the bundled build:
 
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-plugin-han"]
+  "plugin": ["file://~/.claude/plugins/marketplaces/han/plugins/bridges/opencode/dist/index.js"]
 }
 ```
 
-**Option B: Local plugin**
+The `file://` path tracks marketplace updates automatically. (An
+`opencode-plugin-han` npm package is planned but not yet published; if
+you installed the bridge before, replace the bare `"opencode-plugin-han"`
+spec with the `file://` path above.)
+
+**Alternative: project-local copy**
 
 Copy the `src/` directory to `.opencode/plugins/han-bridge/` in your project.
 
@@ -155,10 +160,9 @@ OpenCode Runtime
   |     └─ client.session.prompt() ─────────────────────┘
   |         (re-prompts agent to fix issues)
   |
-  |-- stop ────────────────────────────────────> Stop hooks (backup)
-  |     (agent signals completion)                  |
-  |                                                 └─ { continue: true }
-  |                                                     (force continuation)
+  |-- experimental.session.compacting ─────────> PreCompact hooks
+  |     (before context compaction)                (hook output appended to
+  |                                                 the compaction prompt)
   |
   |-- tool: han_skills ────────────────────────> Skill discovery
   |     (LLM-callable)                             (list/search/load 400+ skills)

--- a/plugins/bridges/opencode/dist/discovery.js
+++ b/plugins/bridges/opencode/dist/discovery.js
@@ -8,7 +8,7 @@
  * This replaces `han hook dispatch`'s discovery with direct filesystem
  * reads, giving the bridge full control over hook execution.
  */
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 /**
@@ -53,20 +53,22 @@ function getEnabledPlugins(projectDir) {
 }
 // ─── Marketplace Resolution ──────────────────────────────────────────────────
 /**
- * Find the marketplace.json file. Searches up from projectDir to find
- * the han repository root, or falls back to the npm-installed marketplace.
+ * Candidate .claude-plugin dirs that may contain the han marketplace.json.
+ * Besides project-relative and home locations, this includes marketplaces
+ * installed by Claude Code under ~/.claude/plugins/marketplaces/<name>/,
+ * which is where `han plugin install` registers the han marketplace.
  */
-function findMarketplace(projectDir) {
-    // Check well-known locations
+function marketplaceCandidateDirs(projectDir) {
     const candidates = [
-        join(projectDir, '.claude-plugin', 'marketplace.json'),
-        join(homedir(), '.claude', 'marketplace.json'),
+        join(projectDir, '.claude-plugin'),
+        join(homedir(), '.claude'),
     ];
     // Walk up directories looking for .claude-plugin/marketplace.json
     let dir = projectDir;
     for (let i = 0; i < 10; i++) {
-        const candidate = join(dir, '.claude-plugin', 'marketplace.json');
-        if (existsSync(candidate) && !candidates.includes(candidate)) {
+        const candidate = join(dir, '.claude-plugin');
+        if (existsSync(join(candidate, 'marketplace.json')) &&
+            !candidates.includes(candidate)) {
             candidates.unshift(candidate);
         }
         const parent = dirname(dir);
@@ -74,16 +76,56 @@ function findMarketplace(projectDir) {
             break;
         dir = parent;
     }
-    for (const path of candidates) {
+    // Installed marketplaces: ~/.claude/plugins/marketplaces/<name>/.claude-plugin
+    const installedRoot = join(homedir(), '.claude', 'plugins', 'marketplaces');
+    if (existsSync(installedRoot)) {
+        try {
+            for (const entry of readdirSync(installedRoot, { withFileTypes: true })) {
+                if (!entry.isDirectory())
+                    continue;
+                const candidate = join(installedRoot, entry.name, '.claude-plugin');
+                if (existsSync(join(candidate, 'marketplace.json'))) {
+                    candidates.push(candidate);
+                }
+            }
+        }
+        catch {
+            // Ignore unreadable marketplace directories
+        }
+    }
+    return candidates;
+}
+/**
+ * Locate the han marketplace.json and its directory. Candidates are checked
+ * in order (project walk-up first, then well-known dirs, then installed
+ * marketplaces); a marketplace named "han" always wins over an unnamed or
+ * differently named one.
+ */
+function findMarketplaceLocation(projectDir) {
+    let fallback = null;
+    for (const dir of marketplaceCandidateDirs(projectDir)) {
+        const path = join(dir, 'marketplace.json');
         if (!existsSync(path))
             continue;
         try {
-            const content = readFileSync(path, 'utf-8');
-            return JSON.parse(content);
+            const marketplace = JSON.parse(readFileSync(path, 'utf-8'));
+            if (!marketplace || !Array.isArray(marketplace.plugins))
+                continue;
+            if (marketplace.name === 'han')
+                return { dir, marketplace };
+            if (!fallback)
+                fallback = { dir, marketplace };
         }
         catch { }
     }
-    return null;
+    return fallback;
+}
+/**
+ * Find the marketplace.json file. Searches up from projectDir to find
+ * the han repository root, then installed marketplaces.
+ */
+function findMarketplace(projectDir) {
+    return findMarketplaceLocation(projectDir)?.marketplace ?? null;
 }
 /**
  * Resolve a plugin name to its filesystem path using the marketplace.
@@ -269,26 +311,11 @@ export function resolvePluginPaths(projectDir) {
     return resolved;
 }
 /**
- * Find the directory containing marketplace.json.
+ * Find the directory containing the marketplace.json that findMarketplace
+ * would parse (same candidate order, same validity check).
  */
 function findMarketplaceDir(projectDir) {
-    const candidates = [
-        join(projectDir, '.claude-plugin'),
-        join(homedir(), '.claude'),
-    ];
-    let dir = projectDir;
-    for (let i = 0; i < 10; i++) {
-        const candidate = join(dir, '.claude-plugin');
-        if (existsSync(join(candidate, 'marketplace.json')) &&
-            !candidates.includes(candidate)) {
-            candidates.unshift(candidate);
-        }
-        const parent = dirname(dir);
-        if (parent === dir)
-            break;
-        dir = parent;
-    }
-    return (candidates.find((d) => existsSync(join(d, 'marketplace.json'))) ?? null);
+    return findMarketplaceLocation(projectDir)?.dir ?? null;
 }
 /**
  * Discover all hook definitions from installed Han plugins.

--- a/plugins/bridges/opencode/dist/index.d.ts
+++ b/plugins/bridges/opencode/dist/index.d.ts
@@ -141,8 +141,11 @@ declare function hanBridgePlugin(ctx: OpenCodePluginContext): Promise<{
         system: string[];
     }) => Promise<void>;
     'chat.message': (_input: Record<string, unknown>, output: {
-        message: string;
-        parts: unknown[];
+        message: unknown;
+        parts: Array<{
+            type: string;
+            text?: string;
+        }>;
     }) => Promise<void>;
     /**
      * tool.execute.before → PreToolUse hooks

--- a/plugins/bridges/opencode/dist/index.js
+++ b/plugins/bridges/opencode/dist/index.js
@@ -45,25 +45,31 @@ const PREFIX = '[han]';
 /**
  * Extract file path(s) from an OpenCode tool event.
  *
- * OpenCode provides tool output with title/output/metadata.
- * For edit/write tools, the file path is typically in the metadata
- * or can be inferred from the tool output.
+ * The edit/write tools receive the target path in `input.args.filePath`;
+ * fall back to output metadata and title for tools that surface it there.
  */
-function extractFilePaths(_input, output) {
+function extractFilePaths(input, output) {
     const paths = [];
+    const push = (p) => {
+        if (typeof p === 'string' && p && !paths.includes(p))
+            paths.push(p);
+    };
+    // Tool args (write/edit/multiedit all take filePath)
+    if (input.args) {
+        push(input.args.filePath);
+        push(input.args.file_path);
+        push(input.args.path);
+    }
     // Check metadata for file path
     if (output.metadata) {
         const meta = output.metadata;
-        if (typeof meta.path === 'string')
-            paths.push(meta.path);
-        if (typeof meta.file_path === 'string')
-            paths.push(meta.file_path);
-        if (typeof meta.filePath === 'string')
-            paths.push(meta.filePath);
+        push(meta.path);
+        push(meta.file_path);
+        push(meta.filePath);
     }
-    // Check title for file path (common pattern: "Edit: src/foo.ts")
+    // Check title for file path (common patterns: "Edit: src/foo.ts", "Write src/foo.ts")
     if (paths.length === 0 && output.title) {
-        const titleMatch = output.title.match(/(?:edit|write|create|modify):\s*(.+)/i);
+        const titleMatch = output.title.match(/(?:edit|write|create|modify):?\s+(.+)/i);
         if (titleMatch) {
             paths.push(titleMatch[1].trim());
         }
@@ -296,8 +302,16 @@ async function hanBridgePlugin(ctx) {
         // Mirrors Claude Code's UserPromptSubmit hook: inject datetime
         // on each user message so the LLM knows the current time.
         'chat.message': async (_input, output) => {
+            // Append to the user's existing text part rather than pushing a new
+            // part: opencode requires durable parts to carry id/sessionID/messageID,
+            // which only the server can assign.
             const timeContext = buildPromptContext();
-            output.parts.push({ type: 'text', text: `\n\n${timeContext}` });
+            const textPart = [...output.parts]
+                .reverse()
+                .find((p) => p.type === 'text' && typeof p.text === 'string');
+            if (textPart) {
+                textPart.text = `${textPart.text}\n\n${timeContext}`;
+            }
         },
         // ─── Hook Handlers ───────────────────────────────────────────────────
         /**

--- a/plugins/bridges/opencode/dist/types.d.ts
+++ b/plugins/bridges/opencode/dist/types.d.ts
@@ -52,6 +52,7 @@ export interface ToolEventInput {
     tool: string;
     sessionID: string;
     callID: string;
+    args?: Record<string, unknown>;
 }
 export interface ToolEventOutput {
     title: string;

--- a/plugins/bridges/opencode/src/discovery.ts
+++ b/plugins/bridges/opencode/src/discovery.ts
@@ -9,7 +9,7 @@
  * reads, giving the bridge full control over hook execution.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { HookDefinition } from './types';
@@ -33,6 +33,7 @@ interface MarketplacePlugin {
 }
 
 interface Marketplace {
+  name?: string;
   plugins: MarketplacePlugin[];
 }
 
@@ -83,21 +84,25 @@ function getEnabledPlugins(projectDir: string): string[] {
 // ─── Marketplace Resolution ──────────────────────────────────────────────────
 
 /**
- * Find the marketplace.json file. Searches up from projectDir to find
- * the han repository root, or falls back to the npm-installed marketplace.
+ * Candidate .claude-plugin dirs that may contain the han marketplace.json.
+ * Besides project-relative and home locations, this includes marketplaces
+ * installed by Claude Code under ~/.claude/plugins/marketplaces/<name>/,
+ * which is where `han plugin install` registers the han marketplace.
  */
-function findMarketplace(projectDir: string): Marketplace | null {
-  // Check well-known locations
+function marketplaceCandidateDirs(projectDir: string): string[] {
   const candidates = [
-    join(projectDir, '.claude-plugin', 'marketplace.json'),
-    join(homedir(), '.claude', 'marketplace.json'),
+    join(projectDir, '.claude-plugin'),
+    join(homedir(), '.claude'),
   ];
 
   // Walk up directories looking for .claude-plugin/marketplace.json
   let dir = projectDir;
   for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, '.claude-plugin', 'marketplace.json');
-    if (existsSync(candidate) && !candidates.includes(candidate)) {
+    const candidate = join(dir, '.claude-plugin');
+    if (
+      existsSync(join(candidate, 'marketplace.json')) &&
+      !candidates.includes(candidate)
+    ) {
       candidates.unshift(candidate);
     }
     const parent = dirname(dir);
@@ -105,15 +110,63 @@ function findMarketplace(projectDir: string): Marketplace | null {
     dir = parent;
   }
 
-  for (const path of candidates) {
+  // Installed marketplaces: ~/.claude/plugins/marketplaces/<name>/.claude-plugin
+  const installedRoot = join(homedir(), '.claude', 'plugins', 'marketplaces');
+  if (existsSync(installedRoot)) {
+    try {
+      for (const entry of readdirSync(installedRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const candidate = join(installedRoot, entry.name, '.claude-plugin');
+        if (existsSync(join(candidate, 'marketplace.json'))) {
+          candidates.push(candidate);
+        }
+      }
+    } catch {
+      // Ignore unreadable marketplace directories
+    }
+  }
+
+  return candidates;
+}
+
+interface MarketplaceLocation {
+  dir: string;
+  marketplace: Marketplace;
+}
+
+/**
+ * Locate the han marketplace.json and its directory. Candidates are checked
+ * in order (project walk-up first, then well-known dirs, then installed
+ * marketplaces); a marketplace named "han" always wins over an unnamed or
+ * differently named one.
+ */
+function findMarketplaceLocation(
+  projectDir: string
+): MarketplaceLocation | null {
+  let fallback: MarketplaceLocation | null = null;
+
+  for (const dir of marketplaceCandidateDirs(projectDir)) {
+    const path = join(dir, 'marketplace.json');
     if (!existsSync(path)) continue;
     try {
-      const content = readFileSync(path, 'utf-8');
-      return JSON.parse(content) as Marketplace;
+      const marketplace = JSON.parse(readFileSync(path, 'utf-8')) as
+        | Marketplace
+        | undefined;
+      if (!marketplace || !Array.isArray(marketplace.plugins)) continue;
+      if (marketplace.name === 'han') return { dir, marketplace };
+      if (!fallback) fallback = { dir, marketplace };
     } catch {}
   }
 
-  return null;
+  return fallback;
+}
+
+/**
+ * Find the marketplace.json file. Searches up from projectDir to find
+ * the han repository root, then installed marketplaces.
+ */
+function findMarketplace(projectDir: string): Marketplace | null {
+  return findMarketplaceLocation(projectDir)?.marketplace ?? null;
 }
 
 /**
@@ -339,31 +392,11 @@ export function resolvePluginPaths(projectDir: string): Map<string, string> {
 }
 
 /**
- * Find the directory containing marketplace.json.
+ * Find the directory containing the marketplace.json that findMarketplace
+ * would parse (same candidate order, same validity check).
  */
 function findMarketplaceDir(projectDir: string): string | null {
-  const candidates = [
-    join(projectDir, '.claude-plugin'),
-    join(homedir(), '.claude'),
-  ];
-
-  let dir = projectDir;
-  for (let i = 0; i < 10; i++) {
-    const candidate = join(dir, '.claude-plugin');
-    if (
-      existsSync(join(candidate, 'marketplace.json')) &&
-      !candidates.includes(candidate)
-    ) {
-      candidates.unshift(candidate);
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-
-  return (
-    candidates.find((d) => existsSync(join(d, 'marketplace.json'))) ?? null
-  );
+  return findMarketplaceLocation(projectDir)?.dir ?? null;
 }
 
 /**

--- a/plugins/bridges/opencode/src/index.ts
+++ b/plugins/bridges/opencode/src/index.ts
@@ -74,28 +74,37 @@ const PREFIX = '[han]';
 /**
  * Extract file path(s) from an OpenCode tool event.
  *
- * OpenCode provides tool output with title/output/metadata.
- * For edit/write tools, the file path is typically in the metadata
- * or can be inferred from the tool output.
+ * The edit/write tools receive the target path in `input.args.filePath`;
+ * fall back to output metadata and title for tools that surface it there.
  */
 function extractFilePaths(
-  _input: ToolEventInput,
+  input: ToolEventInput,
   output: ToolEventOutput
 ): string[] {
   const paths: string[] = [];
+  const push = (p: unknown) => {
+    if (typeof p === 'string' && p && !paths.includes(p)) paths.push(p);
+  };
+
+  // Tool args (write/edit/multiedit all take filePath)
+  if (input.args) {
+    push(input.args.filePath);
+    push(input.args.file_path);
+    push(input.args.path);
+  }
 
   // Check metadata for file path
   if (output.metadata) {
     const meta = output.metadata as Record<string, unknown>;
-    if (typeof meta.path === 'string') paths.push(meta.path);
-    if (typeof meta.file_path === 'string') paths.push(meta.file_path);
-    if (typeof meta.filePath === 'string') paths.push(meta.filePath);
+    push(meta.path);
+    push(meta.file_path);
+    push(meta.filePath);
   }
 
-  // Check title for file path (common pattern: "Edit: src/foo.ts")
+  // Check title for file path (common patterns: "Edit: src/foo.ts", "Write src/foo.ts")
   if (paths.length === 0 && output.title) {
     const titleMatch = output.title.match(
-      /(?:edit|write|create|modify):\s*(.+)/i
+      /(?:edit|write|create|modify):?\s+(.+)/i
     );
     if (titleMatch) {
       paths.push(titleMatch[1].trim());
@@ -391,10 +400,18 @@ async function hanBridgePlugin(ctx: OpenCodePluginContext) {
 
     'chat.message': async (
       _input: Record<string, unknown>,
-      output: { message: string; parts: unknown[] }
+      output: { message: unknown; parts: Array<{ type: string; text?: string }> }
     ) => {
+      // Append to the user's existing text part rather than pushing a new
+      // part: opencode requires durable parts to carry id/sessionID/messageID,
+      // which only the server can assign.
       const timeContext = buildPromptContext();
-      output.parts.push({ type: 'text', text: `\n\n${timeContext}` });
+      const textPart = [...output.parts]
+        .reverse()
+        .find((p) => p.type === 'text' && typeof p.text === 'string');
+      if (textPart) {
+        textPart.text = `${textPart.text}\n\n${timeContext}`;
+      }
     },
 
     // ─── Hook Handlers ───────────────────────────────────────────────────

--- a/plugins/bridges/opencode/src/types.ts
+++ b/plugins/bridges/opencode/src/types.ts
@@ -54,6 +54,7 @@ export interface ToolEventInput {
   tool: string;
   sessionID: string;
   callID: string;
+  args?: Record<string, unknown>;
 }
 
 export interface ToolEventOutput {

--- a/website/content/docs/installation/gemini-cli.md
+++ b/website/content/docs/installation/gemini-cli.md
@@ -75,15 +75,17 @@ The bridge maps Claude Code's hook events to Gemini CLI's extension hooks:
 
 | Claude Code Hook | Gemini CLI Equivalent | Status | Notes |
 |---|---|---|---|
-| **PostToolUse** | `AfterTool` | Implemented | Primary validation — per-file linting/formatting |
+| **PostToolUse** | `AfterTool` | Implemented | Primary validation — per-file linting/formatting; failures return `decision: "deny"` so the tool result is replaced by the validation feedback |
 | **PreToolUse** | `BeforeTool` | Implemented | Pre-execution gates, can deny tool execution |
 | **Stop** | `AfterAgent` | Implemented | Full project validation, blocks agent on failure |
 | **SessionStart** | `SessionStart` | Implemented | Plugin discovery, coordinator start, capability summary |
+| **SessionEnd** | `SessionEnd` | Implemented | Runs Han SessionEnd hooks and flushes the event log |
 | **UserPromptSubmit** | `BeforeAgent` | Implemented | Current datetime injected as additional context |
 | **PreCompact** | `PreCompress` | Implemented | Event log flush before context compression |
 | **Skills** | GEMINI.md context | Partial | Skills discovered and counted; use Gemini CLI's native skill system |
 | **Disciplines** | GEMINI.md context | Partial | Disciplines discovered and counted |
 | **Event Logging** | JSONL + coordinator | Implemented | Browse UI visibility for Gemini CLI sessions |
+| BeforeModel/AfterModel/BeforeToolSelection | — | Intentionally unsupported | Han has no model-level hooks |
 | SubagentStart/Stop | — | Not available | No Gemini CLI equivalent |
 | MCP tool events | — | Not available | AfterTool doesn't fire for MCP tool calls |
 

--- a/website/content/docs/installation/kiro.md
+++ b/website/content/docs/installation/kiro.md
@@ -55,6 +55,10 @@ kiro-cli chat --agent han
 
 That's it. Your Han plugins now work in Kiro.
 
+The shipped agent config declares the built-in tools the agent needs (`fs_read`, `fs_write`, `execute_bash`, `glob`, `grep`). Without a `tools` list Kiro gives a custom agent no tools at all, and the model prints fake `<fs_write>` blocks instead of writing files.
+
+Kiro asks for approval before tool calls by default. To pre-approve tools, add an `allowedTools` list to the agent config, or run with `kiro-cli chat --agent han --trust-all-tools` (sandboxed environments only).
+
 ## Coverage Matrix
 
 The bridge maps Claude Code's hook events to Kiro's hook system:
@@ -63,7 +67,7 @@ The bridge maps Claude Code's hook events to Kiro's hook system:
 |---|---|---|---|
 | **PostToolUse** | `postToolUse` | Implemented | Primary validation path - per-file linting/formatting |
 | **PreToolUse** | `preToolUse` | Implemented | Pre-execution gates with exit code 2 blocking |
-| **Stop** | `stop` | Implemented | Full project validation when agent finishes |
+| **Stop** | `stop` | Implemented | Full project validation; failures emit `{"decision":"block","reason":...}` so the agent keeps working until validation passes |
 | **SessionStart** | `agentSpawn` | Implemented | Core guidelines injected on agent start |
 | **UserPromptSubmit** | `userPromptSubmit` | Implemented | Current datetime injected on every prompt |
 | **Event Logging** | JSONL + coordinator | Implemented | Browse UI visibility for Kiro sessions |

--- a/website/content/docs/installation/opencode.md
+++ b/website/content/docs/installation/opencode.md
@@ -33,14 +33,16 @@ han plugin install --auto
 
 ### 2. Add the bridge to OpenCode
 
-Add to your `opencode.json`:
+The bridge ships with the han marketplace (installed in step 1). Point opencode at the bundled build in your `opencode.json`:
 
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-plugin-han"]
+  "plugin": ["file://~/.claude/plugins/marketplaces/han/plugins/bridges/opencode/dist/index.js"]
 }
 ```
+
+The `file://` path tracks marketplace updates automatically. (An `opencode-plugin-han` npm package is planned but not yet published.)
 
 That's it. Your Han plugins now work in OpenCode.
 
@@ -52,7 +54,7 @@ The bridge maps Claude Code's hook events to OpenCode's plugin API:
 |---|---|---|---|
 | **PostToolUse** | `tool.execute.after` | Implemented | Primary validation path - per-file linting/formatting |
 | **PreToolUse** | `tool.execute.before` | Implemented | Pre-execution gates, subagent context injection |
-| **Stop** | `stop` + `session.idle` | Implemented | Full project validation when agent finishes |
+| **Stop** | `session.idle` | Implemented | Full project validation when agent finishes |
 | **SessionStart** | `experimental.chat.system.transform` | Implemented | Core guidelines injected into system prompt |
 | **UserPromptSubmit** | `chat.message` | Implemented | Current datetime injected on every prompt |
 | **SubagentPrompt** | `tool.execute.before` (Task/agent) | Implemented | Discipline context injected into subagent prompts |
@@ -62,7 +64,7 @@ The bridge maps Claude Code's hook events to OpenCode's plugin API:
 | SubagentStart/Stop | — | Not available | No OpenCode equivalent |
 | MCP tool events | — | Not available | OpenCode doesn't fire events for MCP calls ([#2319](https://github.com/sst/opencode/issues/2319)) |
 | Permission denial | — | Not available | `tool.execute.before` can't block tool execution |
-| PreCompact | — | Not available | No OpenCode equivalent |
+| PreCompact | `experimental.session.compacting` | Implemented | Hook output appended to the compaction prompt |
 | Session slug | — | Not available | OpenCode uses its own session naming |
 
 ## What Works
@@ -170,7 +172,6 @@ These are genuine platform limitations that cannot be bridged:
 - **MCP tool events**: OpenCode doesn't fire `tool.execute.after` for MCP tool calls ([opencode#2319](https://github.com/sst/opencode/issues/2319)). Validation only runs for built-in tools (edit, write, bash).
 - **Subagent hooks**: No OpenCode equivalent for SubagentStart/SubagentStop. Discipline context is injected via `tool.execute.before` as a workaround.
 - **Permission denial**: OpenCode's `tool.execute.before` cannot block tool execution (no `permissionDecision` equivalent). PreToolUse hooks can warn but not deny.
-- **PreCompact**: No hook before context compaction.
 - **Checkpoint filtering**: Session-scoped checkpoint filtering (only validate files changed since last checkpoint) is not yet implemented in the bridge.
 
 ## How Plugins Stay Compatible


### PR DESCRIPTION
## What this is

Follow-up to #100: instead of verifying spec compliance by construction, I installed every harness and ran real headless sessions against a fixture project (a TypeScript repo with planted type errors and Han's core/biome/typescript plugins enabled). Four genuine integration bugs surfaced that spec review could not catch, plus one discovery gap that made every bridge a no-op outside the han repo.

## Bugs found by live testing

1. **Discovery gap (all 5 bridges)**: bridges only searched for `.claude-plugin/marketplace.json` walking up from the project dir. In any real project the marketplace lives at `~/.claude/plugins/marketplaces/han/`, so discovery resolved **zero plugins everywhere outside the han repo itself**. All bridges now scan installed marketplaces and prefer the one named `han`.
2. **opencode**: `chat.message` pushed a bare text part missing `id`/`sessionID`/`messageID`. Current opencode rejects it (`InvalidDurableEvent`) and the **entire prompt failed with a server error** — the bridge bricked every session where discovery succeeded. Datetime now merges into the user's existing text part. (This is why the stale global plugin appeared to "work": its discovery failure made it return `{}` before registering any hooks.)
3. **opencode**: `extractFilePaths` ignored `input.args` (where write/edit put `filePath`) and required a colon in the tool title — PostToolUse hooks never matched a single edit. Now reads args first, tolerates `Write src/foo.ts` titles.
4. **gemini-cli**: `gemini-hooks.json` was a bare event map; Gemini 0.51 requires a top-level `hooks` object. The extension loaded with **zero hooks** and an 'invalid hooks configuration' error.
5. **kiro**: `kiro-agent.json` had no `tools` list. Without one, a custom Kiro agent has **no tools at all** — the model printed fake `<fs_write>` XML as text and never wrote a file.

## Live verification (real harness sessions, not mocks)

| Harness | Version | Result |
|---|---|---|
| Claude Code | 2.1.215 | Plugins load from enabledPlugins; SessionStart context hooks run; PostToolUse/Stop hooks fire (marker-verified); `han hook run typescript typecheck` catches planted errors |
| Codex | 0.144.4 | SessionStart/UserPromptSubmit/PostToolUse/Stop hooks fire via real hook pipeline; `typescript/typecheck` Stop hook exits 1 with the planted TS2322 errors, agent reacts; JSONL logged with `provider: codex` |
| opencode | 1.18.0 | File change logged; `biome/lint` (exit 0, auto-fixed) and `typescript/typecheck-async` (exit 1) PostToolUse results delivered to the agent inline |
| Gemini CLI | 0.51.0 | AfterTool **blocked a write_file call** with Han validation output (`decision: "deny"`); session continued under feedback; events logged |
| Kiro CLI | 2.13.0 | userPromptSubmit context confirmed in session transcript; fs_write logged; **stop hook ran typecheck (exit 1), block decision re-prompted the agent, which iterated until typecheck passed (exit 0)** |

## Docs (covers all of today's work)

- opencode: install now uses the marketplace-clone `file://` path — the `opencode-plugin-han` npm package was never published (404); `han setup --agent opencode` updated to match. Coverage matrix: Stop via `session.idle`, PreCompact via `experimental.session.compacting`
- gemini-cli: SessionEnd + deny-based AfterTool in the matrix; model-level hooks documented as intentionally unsupported
- kiro: `tools` requirement and trust options (`allowedTools`, `--trust-all-tools`); stop block-decision behavior
- CHANGELOG entries for all five bridges

## Not fixed / noted

- `opencode-plugin-han` npm package is still unpublished; docs now steer to the `file://` install
- Gemini extension installed at `~/.gemini/extensions/han` during testing (the documented install path)
- Jason's global `~/.config/opencode/opencode.json` points at a stale bridge build in `~/.worktrees/han-opencode-npm-tui` — worth updating to the marketplace-clone path
