### PR TITLE
fix(han): sanitize Windows project path slugs

### DIFF
--- a/packages/han/lib/memory/paths.ts
+++ b/packages/han/lib/memory/paths.ts
@@ -182,14 +182,15 @@ export function getClaudeProjectsDir(): string {
 
 /**
  * Convert a filesystem path to Claude Code's project slug format
- * Claude Code replaces both `/` and `.` with `-`
+ * Claude Code replaces path separators and dots with `-`, and omits the
+ * colon after a Windows drive letter.
  *
  * @example
  * pathToSlug("/Volumes/dev/src/github.com/foo/bar") // "-Volumes-dev-src-github-com-foo-bar"
+ * pathToSlug("C:\\Users\\foo\\bar") // "C-Users-foo-bar"
  */
 export function pathToSlug(fsPath: string): string {
-  // Replace path separators and dots with dashes, removing leading slashes
-  return fsPath.replace(/^\//, '-').replace(/[/.]/g, '-');
+  return fsPath.replace(/^([A-Za-z]):/, '$1').replace(/[\\/:.]/g, '-');
 }
 
 /**

--- a/packages/han/lib/memory/paths.ts
+++ b/packages/han/lib/memory/paths.ts
@@ -182,15 +182,14 @@ export function getClaudeProjectsDir(): string {
 
 /**
  * Convert a filesystem path to Claude Code's project slug format
- * Claude Code replaces path separators and dots with `-`, and omits the
- * colon after a Windows drive letter.
+ * Claude Code replaces path separators, dots, and drive-letter colons with `-`.
  *
  * @example
  * pathToSlug("/Volumes/dev/src/github.com/foo/bar") // "-Volumes-dev-src-github-com-foo-bar"
- * pathToSlug("C:\\Users\\foo\\bar") // "C-Users-foo-bar"
+ * pathToSlug("C:\\Users\\foo\\bar") // "C--Users-foo-bar"
  */
 export function pathToSlug(fsPath: string): string {
-  return fsPath.replace(/^([A-Za-z]):/, '$1').replace(/[\\/:.]/g, '-');
+  return fsPath.replace(/[\\/:.]/g, '-');
 }
 
 /**

--- a/packages/han/lib/memory/transcript-search.ts
+++ b/packages/han/lib/memory/transcript-search.ts
@@ -23,7 +23,9 @@ import {
   initTable,
   searchFts,
 } from './indexer.ts';
-import { getGitRemote, normalizeGitRemote } from './paths.ts';
+import { getGitRemote, normalizeGitRemote, pathToSlug } from './paths.ts';
+
+export { pathToSlug } from './paths.ts';
 
 /**
  * Transcript message types
@@ -133,14 +135,6 @@ export interface TranscriptSearchResult {
 export function getClaudeProjectsDir(): string {
   const home = process.env.HOME || homedir();
   return join(home, '.claude', 'projects');
-}
-
-/**
- * Convert a filesystem path to Claude project slug
- * e.g., /Volumes/dev/src/github.com/foo -> -Volumes-dev-src-github-com-foo
- */
-export function pathToSlug(path: string): string {
-  return path.replace(/[/.]/g, '-');
 }
 
 /**

--- a/packages/han/lib/memory/transcript-search.ts
+++ b/packages/han/lib/memory/transcript-search.ts
@@ -169,9 +169,9 @@ export function slugToPath(slug: string): string {
   else if (path.startsWith('tmp-') || path.startsWith('private-tmp-')) {
     path = `/${path.replace(/-/g, '/')}`;
   }
-  // C:\... (Windows)
-  else if (/^[A-Z]-/.test(path)) {
-    path = `${path[0]}:\\${path.slice(2).replace(/-/g, '\\')}`;
+  // C:\... (Windows); Claude replaces both the drive colon and separator.
+  else if (/^[A-Za-z]--/.test(path)) {
+    path = `${path[0]}:\\${path.slice(3).replace(/-/g, '\\')}`;
   }
   // Default: assume Unix-style path
   else {

--- a/packages/han/test/han-events-path.test.ts
+++ b/packages/han/test/han-events-path.test.ts
@@ -11,6 +11,7 @@ import {
   getHanEventsFilePath,
   getSessionFilePath,
   getSessionsPath,
+  pathToSlug,
   setMemoryRoot,
 } from '../lib/memory/paths.ts';
 
@@ -87,5 +88,11 @@ describe('Han Events Path Resolution', () => {
     const date = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
 
     expect(hanEventsPath).toContain(date);
+  });
+
+  test('project slugs sanitize Windows drive letters and separators', () => {
+    expect(pathToSlug('C:\\Users\\user\\Projects\\example-app')).toBe(
+      'C-Users-user-Projects-example-app'
+    );
   });
 });

--- a/packages/han/test/han-events-path.test.ts
+++ b/packages/han/test/han-events-path.test.ts
@@ -92,7 +92,7 @@ describe('Han Events Path Resolution', () => {
 
   test('project slugs sanitize Windows drive letters and separators', () => {
     expect(pathToSlug('C:\\Users\\user\\Projects\\example-app')).toBe(
-      'C-Users-user-Projects-example-app'
+      'C--Users-user-Projects-example-app'
     );
   });
 });

--- a/packages/han/test/transcript-search.test.ts
+++ b/packages/han/test/transcript-search.test.ts
@@ -65,7 +65,15 @@ describe.serial('transcript search', () => {
       const { pathToSlug } = await import('../lib/memory/transcript-search.ts');
 
       expect(pathToSlug('C:\\Users\\user\\Projects\\example-app')).toBe(
-        'C-Users-user-Projects-example-app'
+        'C--Users-user-Projects-example-app'
+      );
+    });
+
+    test('slugToPath restores Windows project slugs', async () => {
+      const { slugToPath } = await import('../lib/memory/transcript-search.ts');
+
+      expect(slugToPath('C--Users-user-Projects-example-app')).toBe(
+        'C:\\Users\\user\\Projects\\example\\app'
       );
     });
 

--- a/packages/han/test/transcript-search.test.ts
+++ b/packages/han/test/transcript-search.test.ts
@@ -61,6 +61,14 @@ describe.serial('transcript search', () => {
       expect(pathToSlug('/github.com/org/repo')).toBe('-github-com-org-repo');
     });
 
+    test('pathToSlug converts Windows paths to a single slug', async () => {
+      const { pathToSlug } = await import('../lib/memory/transcript-search.ts');
+
+      expect(pathToSlug('C:\\Users\\user\\Projects\\example-app')).toBe(
+        'C-Users-user-Projects-example-app'
+      );
+    });
+
     test('slugToPath converts macOS Volumes paths', async () => {
       const { slugToPath } = await import('../lib/memory/transcript-search.ts');
 


### PR DESCRIPTION
## Summary

Fix Windows project path conversion so Han matches Claude Code’s project-directory slug format (for example, `C:\Users\alice\repo` becomes `C--Users-alice-repo`).

Closes #104.

## Changes

- Convert Windows drive-letter colons and path separators to individual slug separators
- Preserve Claude Code’s double-dash drive prefix (`C--...`)
- Teach reverse conversion to decode uppercase and lowercase Windows drive prefixes
- Re-export the canonical `pathToSlug` implementation from transcript search instead of maintaining a duplicate
- Add regression coverage for Han event paths, transcript lookup, and reverse conversion

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] New plugin

## Plugin Changes

**Plugin category:**
- [x] N/A - Not a plugin change

**Validation:**
- [x] N/A - Not a plugin change

## Testing

- [x] `npm run build:bundle`
- [x] `npm run typecheck`
- [x] Biome passes on all four changed files
- [x] 43 focused transcript, event-path, and marketplace-cache tests pass
- [x] `git diff --check`

The repository-wide test run previously reached 2,148 passing and 58 skipped tests; 13 marketplace-cache tests failed only in that combined run and passed independently. The changed path/transcript scope is green.

## Checklist

- [x] Code follows existing patterns
- [x] Self-review completed
- [x] Documentation updated where needed
- [x] No new warnings

AI-assisted implementation was reviewed against real Claude Code Windows slug examples and validated with focused regression tests.
